### PR TITLE
Fix/1.14.8 ga/jcr 1749

### DIFF
--- a/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/modules/kernel/container-configuration.xml
+++ b/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/modules/kernel/container-configuration.xml
@@ -1423,7 +1423,7 @@ complex-value=${my-var1}-${my-var2}</programlisting></para>
           <section>
             <title><envar>AddDependenciesAfter</envar></title>
 
-            <para>This modification adds a list of dependencies before a given
+            <para>This modification adds a list of dependencies after a given
             target dependency defined into the list of dependencies of the
             <envar>PortalContainerDefinition</envar>. The full qualified name
             is


### PR DESCRIPTION
In "AddDependenciesAfter" subsection of "Understanding how configuration files are loaded" section - Container Configuration chapter.
Please replace the word "before" by "after" in following sentence:
This modification adds a list of dependencies before a given target dependency defined into the list of dependencies of the PortalContainerDefinition.
