### PR TITLE
JCR-1882 1.14.9-GA

### DIFF
--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/resource/FileResource.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/resource/FileResource.java
@@ -224,7 +224,17 @@ public class FileResource extends GenericResource
       }
       else if (name.equals(GETCONTENTTYPE))
       {
-         return new HierarchicalProperty(name, contentNode().getProperty("jcr:mimeType").getString());
+         Node contentNode = contentNode();
+         String mimeType = contentNode.getProperty("jcr:mimeType").getString();
+         if (contentNode.hasProperty("jcr:encoding"))
+         {
+            String encoding = contentNode.getProperty("jcr:encoding").getString();
+            if (!encoding.isEmpty())
+            {
+               return new HierarchicalProperty(name, mimeType + "; charset=" + encoding);
+            }
+         }
+         return new HierarchicalProperty(name, mimeType);
       }
       else if (name.equals(GETLASTMODIFIED))
       {

--- a/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/command/TestGet.java
+++ b/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/command/TestGet.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import javax.jcr.Credentials;
 import javax.jcr.Node;
 import javax.jcr.Session;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
 
@@ -267,6 +268,48 @@ public class TestGet extends BaseStandaloneTest
       XSLTout.write(byteOut);
 
       assertTrue("Response should contain parent collection href", byteOut.toString().contains(folderOne));
+   }
+
+   public void testGetContentTypeWithEncoding() throws Exception
+   {
+      Node fileNode = session.getRootNode().addNode("node", "nt:file");
+      Node contentNode = fileNode.addNode("jcr:content", "nt:resource");
+      contentNode.setProperty("jcr:mimeType", "text/plain");
+      contentNode.setProperty("jcr:encoding", "test-encoding");
+      contentNode.setProperty("jcr:data", "There is no ignorance, there is knowledge.");
+      contentNode.setProperty("jcr:lastModified", Calendar.getInstance());
+      session.save();
+
+      ContainerResponse response = service(WebDAVMethods.GET, getPathWS() + "/" + fileNode.getName(), "", null, null);
+
+      assertEquals("text/plain; charset=test-encoding", response.getHttpHeaders().getFirst(HttpHeaders.CONTENT_TYPE)
+         .toString());
+   }
+
+   public void testGetContentTypeWithNoEncoding() throws Exception
+   {
+      Node fileNode = session.getRootNode().addNode("node", "nt:file");
+      Node contentNode = fileNode.addNode("jcr:content", "nt:resource");
+      contentNode.setProperty("jcr:mimeType", "text/plain");
+      contentNode.setProperty("jcr:encoding", "");
+      contentNode.setProperty("jcr:data", "There is no passion, there is serenity.");
+      contentNode.setProperty("jcr:lastModified", Calendar.getInstance());
+      session.save();
+
+      ContainerResponse response = service(WebDAVMethods.GET, getPathWS() + "/" + fileNode.getName(), "", null, null);
+
+      assertEquals("text/plain", response.getHttpHeaders().getFirst(HttpHeaders.CONTENT_TYPE).toString());
+
+      fileNode = session.getRootNode().addNode("node2", "nt:file");
+      contentNode = fileNode.addNode("jcr:content", "nt:resource");
+      contentNode.setProperty("jcr:mimeType", "text/plain");
+      contentNode.setProperty("jcr:data", "There is no passion, there is serenity.");
+      contentNode.setProperty("jcr:lastModified", Calendar.getInstance());
+      session.save();
+
+      response = service(WebDAVMethods.GET, getPathWS() + "/" + fileNode.getName(), "", null, null);
+
+      assertEquals("text/plain", response.getHttpHeaders().getFirst(HttpHeaders.CONTENT_TYPE).toString());
    }
 
    @Override

--- a/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/command/TestPut.java
+++ b/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/command/TestPut.java
@@ -289,6 +289,21 @@ public class TestPut extends BaseStandaloneTest
       containerResponse = service(WebDAVMethods.GET, getPathWS() + "/" + filename, "", null, null);
       assertEquals(MediaType.TEXT_HTML, containerResponse.getHttpHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
    }
+   public void testPutContentTypeHeaderWithEncoding() throws Exception
+   {
+      String content = TestUtils.getFileContent();
+      String fileName = TestUtils.getFileName();
+
+      MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+      headers.add(ExtHttpHeaders.CONTENT_TYPE, "webdav:goodres; charset=test-char-set");
+      ContainerResponse containerResponse =
+         service(WebDAVMethods.PUT, getPathWS() + fileName, "", headers, content.getBytes());
+
+      assertEquals(HTTPStatus.CREATED, containerResponse.getStatus());
+      assertTrue("Content node is expected to have 'jcr:encoding' property set during PUT method", TestUtils
+         .getContentNode(session, fileName).hasProperty("jcr:encoding"));
+      assertEquals("test-char-set", TestUtils.getContentNode(session, fileName).getProperty("jcr:encoding").getString());
+   }
 
    @Override
    protected String getRepositoryName()

--- a/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/utils/TestUtils.java
+++ b/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/utils/TestUtils.java
@@ -222,6 +222,12 @@ public class TestUtils
 
    }
 
+   public static Node getContentNode(Session session, String path) throws PathNotFoundException, RepositoryException
+   {
+      Node node = session.getRootNode().getNode(TextUtil.relativizePath(path));
+      return node.getNode("jcr:content");
+   }
+
    public static NodeType[] getContentMixins(Session session, String path) throws PathNotFoundException,
       RepositoryException
    {


### PR DESCRIPTION
Now encoding is appended to mime-type in the content-type header in GET response
