### PR TITLE
JCR-2098: Invalid byte 2 of 3-byte UTF-8 sequence while building the doc

### DIFF
--- a/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/master.xml
+++ b/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/master.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
     Copyright (C) 2009 eXo Platform SAS.


### PR DESCRIPTION
https://jira.exoplatform.org/browse/JCR-2098
