### PR TITLE
JCR-2066 :Cannot run benchmark tests with ISPN as underlying cache

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -204,6 +204,10 @@
              <groupId>commons-logging</groupId>
              <artifactId>commons-logging</artifactId>
            </exclusion>
+           <exclusion>
+             <groupId>org.jboss.logging</groupId>
+             <artifactId>jboss-logging-spi</artifactId>
+           </exclusion>
          </exclusions>          
       </dependency>
       <dependency>


### PR DESCRIPTION
JCR-2066 :Cannot run benchmark tests with ISPN as underlying cache
