### PR TITLE
JCR-2186 : InvalidMagicMimeEntryException when starting PLF 3.5.7 on RHE...

### DIFF
--- a/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/modules/jcr/protocols/webdav.xml
+++ b/exo.jcr.docs/exo.jcr.docs.developer/en/src/main/docbook/en-US/modules/jcr/protocols/webdav.xml
@@ -174,6 +174,13 @@
 
   &lt;/init-params&gt;
 &lt;/component&gt;</programlisting>
+      <note>
+        <para>
+            If the MimeTypeResolver throws exceptions of type "eu.medsea.mimeutil.detector.InvalidMagicMimeEntryException: Invalid Magic Mime Entry"
+            on RHEL or CentOS, you should use the mime cache file instead of the magic mime file.
+            To provide the full path to the mime cache file, you will need to use the system property exo.mime.cache.
+        </para>
+     </note>
   </section>
 
   <section id="JCR.WebDAV.Screenshots">


### PR DESCRIPTION
JCR-2186 : InvalidMagicMimeEntryException when starting PLF 3.5.7 on RHEL 5.9
