### PR TITLE
JCR-2205 : Local Index Recovery Filters don't work in JPP6

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/SearchIndex.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/SearchIndex.java
@@ -562,9 +562,9 @@ public class SearchIndex extends AbstractQueryHandler implements IndexerIoModeLi
       this.wsId = wsId;
       this.analyzer = new JcrStandartAnalyzer();
       this.cfm = cfm;
+      this.recoveryFilterClasses = new LinkedHashSet<String>();
       SearchIndexConfigurationHelper searchIndexConfigurationHelper = new SearchIndexConfigurationHelper(this);
       searchIndexConfigurationHelper.init(queryHandlerConfig);
-      this.recoveryFilterClasses = new LinkedHashSet<String>();
    }
 
    /**


### PR DESCRIPTION
JCR-2205 : Local Index Recovery Filters don't work in JPP6
