### PR TITLE
JCR-2364: [Ubuntu] MIME type isn't recognized when uploading file via Na...

### DIFF
--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/MimeTypeRecognizer.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/MimeTypeRecognizer.java
@@ -82,7 +82,9 @@ public class MimeTypeRecognizer
     */
    public String getMimeType()
    {
-      if (mediaType == null || untrustedAgent)
+      // Use file extension in case of "application/octet-stream" (default value since gvfs 1.15.1)
+      if (mediaType == null || untrustedAgent 
+          || MediaType.APPLICATION_OCTET_STREAM.equals(mediaType.getType() + "/" + mediaType.getSubtype()))
       {
          return mimeTypeResolver.getMimeType(fileName);
       }


### PR DESCRIPTION
...utilus

Problem analysis:
* Files uploaded via Nautilus since Ubuntu 13.04 have "application/octet-stream" in Content-Type

Fix description:
* When the Content-Type is "application/octet-stream", use file extension to get its MIME type.