### PR TITLE
JCR-2366: [WebDAV] No size limit when uploading files

### DIFF
--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceImpl.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceImpl.java
@@ -142,6 +142,8 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
 
    private final MimeTypeResolver mimeTypeResolver;
 
+   private long fileSizeLimit; 
+   
    static
    {
       StringBuffer sb = new StringBuffer();
@@ -176,6 +178,7 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
    {
       this(repositoryService, sessionProviderService);
       this.webDavServiceInitParams = new WebDavServiceInitParams(params);
+      this.fileSizeLimit = getFileSizeLimit();
    }
 
    /**
@@ -190,6 +193,7 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
    {
       this(repositoryService, sessionProviderService);
       this.webDavServiceInitParams = new WebDavServiceInitParams(params);
+      this.fileSizeLimit = getFileSizeLimit();
    }
 
    /**
@@ -207,6 +211,7 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
       this.mimeTypeResolver = new MimeTypeResolver();
       this.mimeTypeResolver.setDefaultMimeType(InitParamsDefaults.FILE_MIME_TYPE);
       this.webDavServiceInitParams = new WebDavServiceInitParams();
+      this.fileSizeLimit = getFileSizeLimit();
    }
 
    /**
@@ -1468,4 +1473,23 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
       }
    }
 
+   /**
+    * Get File Size limit in byte
+    */
+   protected long getFileSizeLimit()
+   {
+      try 
+      {  
+         return Long.parseLong(webDavServiceInitParams.getDefaultFileSizeLimit());
+      }
+      catch (Exception e)
+      {
+         if (log.isDebugEnabled())
+         { 	 
+            log.debug("Failed to parse " + webDavServiceInitParams.getDefaultFileSizeLimit() + 
+                     ". Use the default value of " + InitParamsDefaults.FILE_SIZE_LIMIT, e);
+         }
+         return Long.parseLong(InitParamsDefaults.FILE_SIZE_LIMIT);
+      }	   
+   }
 }

--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceInitParams.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceInitParams.java
@@ -75,6 +75,11 @@ public class WebDavServiceInitParams
    private String defaultAutoVersionType = InitParamsDefaults.AUTO_VERSION;
 
    /**
+    * File size limit default value. 
+    */
+   private String defaultFileSizeLimit = InitParamsDefaults.FILE_SIZE_LIMIT; 
+
+   /**
     * XSLT parameters.
     */
    private Map<String, String> xsltParams = new HashMap<String, String>();
@@ -171,6 +176,7 @@ public class WebDavServiceInitParams
       defaultFileMimeType = pmp.processSingleParameter(defaultFileMimeType, InitParamsNames.DEF_FILE_MIME_TYPE);
       defaultUpdatePolicyType = pmp.processSingleParameter(defaultUpdatePolicyType, InitParamsNames.UPDATE_POLICY);
       defaultAutoVersionType = pmp.processSingleParameter(defaultAutoVersionType, InitParamsNames.AUTO_VERSION);
+      defaultFileSizeLimit = pmp.processSingleParameter(defaultFileSizeLimit, InitParamsNames.FILE_SIZE_LIMIT);
 
       pmp.processMultiParameter(untrustedUserAgents, InitParamsNames.UNTRUSTED_USER_AGENTS);
       pmp.processMultiParameter(allowedFileNodeTypes, InitParamsNames.ALLOWED_FILE_NODE_TYPES);
@@ -209,6 +215,11 @@ public class WebDavServiceInitParams
       return defaultAutoVersionType;
    }
 
+   public String getDefaultFileSizeLimit()
+   {
+      return defaultFileSizeLimit;	   
+   }
+   
    public Map<String, String> getXsltParams()
    {
       return xsltParams;
@@ -257,6 +268,11 @@ public class WebDavServiceInitParams
    public void setDefaultAutoVersionType(String defaultAutoVersionType)
    {
       this.defaultAutoVersionType = defaultAutoVersionType;
+   }
+   
+   public void setDefaultFileSizeLimit(String defaultFileSizeLimit)
+   {
+      this.defaultFileSizeLimit = defaultFileSizeLimit;
    }
 
    public void setXsltParams(Map<String, String> xsltParams)

--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/util/InitParamsDefaults.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/util/InitParamsDefaults.java
@@ -53,4 +53,8 @@ public interface InitParamsDefaults
     */
    String AUTO_VERSION = "checkout-checkin";
 
+   /**
+    * File size limitation parameter default value (in bytes)
+    */
+   String FILE_SIZE_LIMIT = "3000000";
 }

--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/util/InitParamsNames.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/util/InitParamsNames.java
@@ -80,5 +80,10 @@ public interface InitParamsNames
     * Initialization parameter {@link String} representation: allowed folder node types list.
     */
    String ALLOWED_FOLDER_NODE_TYPES = "allowed-folder-node-types";
+   
+   /**
+    * Initialization parameter {@link String} representation: size limitation in bytes of file uploaded via WebDAV.
+    */
+   String FILE_SIZE_LIMIT = "file-size-limit";
 
 }

--- a/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/TestWebDavServiceInitParams.java
+++ b/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/TestWebDavServiceInitParams.java
@@ -44,6 +44,7 @@ public class TestWebDavServiceInitParams extends TestCase
       assertEquals(InitParamsDefaults.FILE_MIME_TYPE, params.getDefaultFileMimeType());
       assertEquals(InitParamsDefaults.UPDATE_POLICY, params.getDefaultUpdatePolicyType());
       assertEquals(InitParamsDefaults.AUTO_VERSION, params.getDefaultAutoVersionType());
+      assertEquals(InitParamsDefaults.FILE_SIZE_LIMIT, params.getDefaultFileSizeLimit());
       assertTrue(params.getXsltParams().isEmpty());
       assertTrue(params.getUntrustedUserAgents().isEmpty());
       assertTrue(params.getCacheControlMap().isEmpty());
@@ -85,6 +86,12 @@ public class TestWebDavServiceInitParams extends TestCase
       vp.setName(InitParamsNames.CACHE_CONTROL);
       vp.setValue("text/xml,text/html:max-age=1800;text/*:max-age=777;image/png,image/jpg:max-age=3600;*/*:no-cache;image/*:max-age=555");
       ip.addParameter(vp);
+      // FILE_SIZE_LIMIT
+      vp = new ValueParam();
+      vp.setName(InitParamsNames.FILE_SIZE_LIMIT);
+      vp.setValue(InitParamsNames.FILE_SIZE_LIMIT);
+      ip.addParameter(vp);
+      
       ValuesParam vsp = new ValuesParam();
       vsp.setName(InitParamsNames.UNTRUSTED_USER_AGENTS);
       vsp.getValues().add(InitParamsNames.UNTRUSTED_USER_AGENTS);
@@ -99,7 +106,7 @@ public class TestWebDavServiceInitParams extends TestCase
       vsp.getValues().add(InitParamsNames.ALLOWED_FILE_NODE_TYPES);
       ip.addParameter(vsp);
       
-      assertEquals(11, ip.size());
+      assertEquals(12, ip.size());
       
       // This is required to be able to parse the MimeType
       RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
@@ -111,6 +118,7 @@ public class TestWebDavServiceInitParams extends TestCase
       assertEquals(InitParamsNames.DEF_FILE_MIME_TYPE, params.getDefaultFileMimeType());
       assertEquals(InitParamsNames.UPDATE_POLICY, params.getDefaultUpdatePolicyType());
       assertEquals(InitParamsNames.AUTO_VERSION, params.getDefaultAutoVersionType());
+      assertEquals(InitParamsNames.FILE_SIZE_LIMIT, params.getDefaultFileSizeLimit());
       assertEquals(2, params.getXsltParams().size());
       assertEquals(InitParamsNames.FILE_ICON_PATH, params.getXsltParams().get(InitParamsNames.FILE_ICON_PATH));
       assertEquals(InitParamsNames.FOLDER_ICON_PATH, params.getXsltParams().get(InitParamsNames.FOLDER_ICON_PATH));      

--- a/exo.jcr.component.webdav/src/test/resources/conf/standalone/test-configuration.xml
+++ b/exo.jcr.component.webdav/src/test/resources/conf/standalone/test-configuration.xml
@@ -209,6 +209,12 @@
             <name>file-icon-path</name>
             <value>/absolute/path/to/file</value>
          </value-param>
+         
+         <value-param>
+            <name>file-size-limit</name>
+            <value>2000</value>
+         </value-param>
+         
          <!-- 
             For testing untrusted-user-agents proper treatment.
             Content-type headers of listed here user agents should be


### PR DESCRIPTION
Fix description:
* Add default file size limit into WebDavService's initial parameters.
* Get the file size limit for WebDavService.