### PR TITLE
JCR-2426 : The bloom filters loading slows down the startup with big …

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/JDBCStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/JDBCStorageConnection.java
@@ -1439,7 +1439,7 @@ public abstract class JDBCStorageConnection extends DBConstants implements Works
    /**
     * {@inheritDoc}
     */
-   public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+   public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
       UnsupportedOperationException
    {
       throw new UnsupportedOperationException(

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/CQJDBCStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/CQJDBCStorageConnection.java
@@ -306,15 +306,15 @@ abstract public class CQJDBCStorageConnection extends JDBCStorageConnection
     * {@inheritDoc}
     */
    @Override
-   public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+   public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
       UnsupportedOperationException
    {
       checkIfOpened();
       ResultSet resultSet = null;
       try
       {
-         // query will return all the ACL holder
-         resultSet = findACLHolders();
+         // query will return the ACL holder with limit and offset
+         resultSet = findACLHolders(limit , offset);
          Map<String, ACLHolder> mHolders = new HashMap<String, ACLHolder>();
 
          while (resultSet.next())
@@ -2278,7 +2278,7 @@ abstract public class CQJDBCStorageConnection extends JDBCStorageConnection
       return PATTERN_ESCAPE_STRING;
    }
    
-   protected abstract ResultSet findACLHolders() throws SQLException;
+   protected abstract ResultSet findACLHolders(int limit , int offset) throws SQLException;
 
    protected abstract ResultSet findItemQPathByIdentifierCQ(String identifier) throws SQLException;
 

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/HSQLDBMultiDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/HSQLDBMultiDbJDBCConnection.java
@@ -101,6 +101,11 @@ public class HSQLDBMultiDbJDBCConnection extends MultiDbJDBCConnection
             + " V  where I.PARENT_ID=? and I.I_CLASS=2 and I.ID=V.PROPERTY_ID";
 
       FIND_VALUE_STORAGE_DESC_AND_SIZE = "select bit_length(DATA)/8, STORAGE_DESC from " + JCR_VALUE + " where PROPERTY_ID=?";
+
+      FIND_ACL_HOLDERS =
+         "select I.PARENT_ID, I.P_TYPE " + " from " + JCR_ITEM
+            + " I where I.I_CLASS=2 and (I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]owner'"
+            + " or I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]permissions')  LIMIT ? OFFSET ?";
    }
 
    /**
@@ -223,5 +228,21 @@ public class HSQLDBMultiDbJDBCConnection extends MultiDbJDBCConnection
          }
       }
       return findLastOrderNumber.executeQuery();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
+   {
+      if (findACLHolders == null)
+      {
+         findACLHolders = dbConnection.prepareStatement(FIND_ACL_HOLDERS);
+      }
+      findACLHolders.setInt(1, limit);
+      findACLHolders.setInt(2, offset);
+
+      return findACLHolders.executeQuery();
    }
 }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/HSQLDBSingleDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/HSQLDBSingleDbJDBCConnection.java
@@ -112,6 +112,11 @@ public class HSQLDBSingleDbJDBCConnection extends SingleDbJDBCConnection
             + " and I.CONTAINER_NAME=? and I.ID=V.PROPERTY_ID";
 
       FIND_VALUE_STORAGE_DESC_AND_SIZE = "select bit_length(DATA)/8, STORAGE_DESC from JCR_SVALUE where PROPERTY_ID=?";
+
+      FIND_ACL_HOLDERS =
+         "select I.PARENT_ID, I.P_TYPE" + " from JCR_SITEM I where I.I_CLASS=2 and I.CONTAINER_NAME=?"
+            + " and (I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]owner'"
+            + " or I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]permissions')  LIMIT ? OFFSET ?";
    }
 
    /**
@@ -391,4 +396,27 @@ public class HSQLDBSingleDbJDBCConnection extends SingleDbJDBCConnection
       }
       return findLastOrderNumber.executeQuery();
    }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
+   {
+      if (findACLHolders == null)
+      {
+         findACLHolders = dbConnection.prepareStatement(FIND_ACL_HOLDERS);
+      }
+      else
+      {
+         findACLHolders.clearParameters();
+      }
+
+      findACLHolders.setString(1, this.containerConfig.containerName);
+      findACLHolders.setInt(2, limit);
+      findACLHolders.setInt(3, offset);
+
+      return findACLHolders.executeQuery();
+   }
+
 }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MultiDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MultiDbJDBCConnection.java
@@ -1045,7 +1045,7 @@ public class MultiDbJDBCConnection extends CQJDBCStorageConnection
     * {@inheritDoc}
     */
    @Override
-   protected ResultSet findACLHolders() throws SQLException
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
    {
       if (findACLHolders == null)
       {

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MySQLMultiDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MySQLMultiDbJDBCConnection.java
@@ -102,6 +102,11 @@ public class MySQLMultiDbJDBCConnection extends MultiDbJDBCConnection
          FIND_NODES_BY_PARENTID_CQ.replace("from " + JCR_ITEM + " I, " + JCR_ITEM + " P, " + JCR_VALUE + " V", "from "
             + JCR_ITEM + " I force index (" + JCR_IDX_ITEM_N_ORDER_NUM + "), " + JCR_ITEM + " P force index("
             + JCR_IDX_ITEM_PARENT_NAME + "), " + JCR_VALUE + " V force index (" + JCR_IDX_VALUE_PROPERTY + ")");
+
+      FIND_ACL_HOLDERS =
+         "select I.PARENT_ID, I.P_TYPE " + " from " + JCR_ITEM
+            + " I where I.I_CLASS=2 and (I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]owner'"
+            + " or I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]permissions')  LIMIT ? OFFSET ?";
    }
 
    /**
@@ -182,6 +187,22 @@ public class MySQLMultiDbJDBCConnection extends MultiDbJDBCConnection
          }
       }
       return super.addPropertyRecord(data);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
+   {
+      if (findACLHolders == null)
+      {
+         findACLHolders = dbConnection.prepareStatement(FIND_ACL_HOLDERS);
+      }
+      findACLHolders.setInt(1, limit);
+      findACLHolders.setInt(2, offset);
+
+      return findACLHolders.executeQuery();
    }
 
    @Override

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MySQLSingleDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/MySQLSingleDbJDBCConnection.java
@@ -103,6 +103,11 @@ public class MySQLSingleDbJDBCConnection extends SingleDbJDBCConnection
          FIND_NODES_BY_PARENTID_CQ.replace("from JCR_SITEM I, JCR_SITEM P, JCR_SVALUE V", "from JCR_SITEM I force index ("
             + JCR_IDX_ITEM_N_ORDER_NUM + "), JCR_SITEM P force index (" + JCR_IDX_ITEM_PARENT_NAME
             + "), JCR_SVALUE V force index (" + JCR_IDX_VALUE_PROPERTY + ")");
+
+      FIND_ACL_HOLDERS =
+         "select I.PARENT_ID, I.P_TYPE" + " from JCR_SITEM I where I.I_CLASS=2 and I.CONTAINER_NAME=?"
+            + " and (I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]owner'"
+            + " or I.NAME='[http://www.exoplatform.com/jcr/exo/1.0]permissions')  LIMIT ? OFFSET ?";
    }
 
    /**
@@ -211,4 +216,27 @@ public class MySQLSingleDbJDBCConnection extends SingleDbJDBCConnection
    {
       return !innoDBEngine && parentIdentifier != null && !addedNodes.contains(parentIdentifier);
    }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
+   {
+      if (findACLHolders == null)
+      {
+         findACLHolders = dbConnection.prepareStatement(FIND_ACL_HOLDERS);
+      }
+      else
+      {
+         findACLHolders.clearParameters();
+      }
+
+      findACLHolders.setString(1, this.containerConfig.containerName);
+      findACLHolders.setInt(2, limit);
+      findACLHolders.setInt(3, offset);
+
+      return findACLHolders.executeQuery();
+   }
+
 }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/SingleDbJDBCConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/db/SingleDbJDBCConnection.java
@@ -1066,7 +1066,7 @@ public class SingleDbJDBCConnection extends CQJDBCStorageConnection
     * {@inheritDoc}
     */
    @Override
-   protected ResultSet findACLHolders() throws SQLException
+   protected ResultSet findACLHolders(int limit , int offset) throws SQLException
    {
       if (findACLHolders == null)
       {

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/statistics/StatisticsJDBCStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/statistics/StatisticsJDBCStorageConnection.java
@@ -710,14 +710,14 @@ public class StatisticsJDBCStorageConnection implements WorkspaceStorageConnecti
    /**
     * {@inheritDoc}
     */
-   public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+   public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
       UnsupportedOperationException
    {
       Statistics s = ALL_STATISTICS.get(GET_ACL_HOLDERS);
       try
       {
          s.begin();
-         return wcs.getACLHolders();
+         return wcs.getACLHolders(limit, offset);
       }
       finally
       {

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceDataContainer.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceDataContainer.java
@@ -73,6 +73,10 @@ public interface WorkspaceDataContainer extends DataContainer
 
    public final static String ACL_BF_ELEMENTS_NUMBER = "acl-bloomfilter-elements-number";
 
+   public final static String ACL_BF_PAGE_SIZE = "acl-bloomfilter-page-size";
+
+   public final static String ACL_BF_ENABLED = "acl-bloomfilter-enabled";
+
    /**
     * [G.A] do we need it here or in WorkspaceDataManager better??
     * 

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceStorageConnection.java
@@ -437,7 +437,7 @@ public interface WorkspaceStorageConnection
     * @throws UnsupportedOperationException
     *           if operation is not supported
     */
-   List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException, UnsupportedOperationException;
+   List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException, UnsupportedOperationException;
 
    /**
     * Reads count of nodes in workspace.

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/BaseStandaloneTest.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/BaseStandaloneTest.java
@@ -752,7 +752,7 @@ public abstract class BaseStandaloneTest extends TestCase
          throw new UnsupportedOperationException("TestWorkspaceStorageConnection: operation is unsupported.");
       }
 
-      public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+      public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
          UnsupportedOperationException
       {
          throw new UnsupportedOperationException("TestWorkspaceStorageConnection: operation is unsupported.");

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorksapceDataManagerBloomFilter.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorksapceDataManagerBloomFilter.java
@@ -279,7 +279,7 @@ public class TestCacheableWorksapceDataManagerBloomFilter extends JcrImplBaseTes
        * @see org.exoplatform.services.jcr.impl.dataflow.persistent.CacheableWorkspaceDataManager#getACLHolders()
        */
       @Override
-      public List<ACLHolder> getACLHolders() throws RepositoryException
+      public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException
       {
          return container.holders;
       }

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorkspaceDataManager.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorkspaceDataManager.java
@@ -1018,7 +1018,7 @@ public class TestCacheableWorkspaceDataManager
       /**
        * @see org.exoplatform.services.jcr.storage.WorkspaceStorageConnection#getACLHolders()
        */
-      public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+      public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
          UnsupportedOperationException
       {
          return null;

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestUUIDWorkspaceStorageCache.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestUUIDWorkspaceStorageCache.java
@@ -177,7 +177,7 @@ public class TestUUIDWorkspaceStorageCache extends JcrAPIBaseTest
 
    public void testUUIDGetACLHolders() throws RepositoryException
    {
-      List<ACLHolder> holders = cwdm.getACLHolders();
+      List<ACLHolder> holders = cwdm.getACLHolders(0, 1000);
       for (int i = 0, length = holders.size(); i < length; i++)
       {
          assertFalse(holders.get(i).getId().startsWith(wdc.getName()));

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestWorkspaceStorageCacheInClusterMode.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestWorkspaceStorageCacheInClusterMode.java
@@ -989,7 +989,7 @@ public abstract class TestWorkspaceStorageCacheInClusterMode<T extends Workspace
       /**
        * @see org.exoplatform.services.jcr.storage.WorkspaceStorageConnection#getACLHolders()
        */
-      public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+      public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
          UnsupportedOperationException
       {
          return null;

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/cache/infinispan/TestISPNCacheWorkspaceStorageCache.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/cache/infinispan/TestISPNCacheWorkspaceStorageCache.java
@@ -387,7 +387,7 @@ public class TestISPNCacheWorkspaceStorageCache extends WorkspaceStorageCacheBas
       /**
        * @see org.exoplatform.services.jcr.storage.WorkspaceStorageConnection#getACLHolders()
        */
-      public List<ACLHolder> getACLHolders() throws RepositoryException, IllegalStateException,
+      public List<ACLHolder> getACLHolders(int limit , int offset) throws RepositoryException, IllegalStateException,
          UnsupportedOperationException
       {
          return null;


### PR DESCRIPTION
JCR-2426 : The bloom filters loading slows down the startup with big database (Part-1).
- Add lazyLoading logic to bloomFilter
- introduce acl-bloomfilter-page-size and acl-bloomfilter-enabled 
