### PR TITLE
JCR Index Clustering : implement Persistent Changelog Strategy (#65)

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/config/QueryHandlerParams.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/config/QueryHandlerParams.java
@@ -103,6 +103,8 @@ public interface QueryHandlerParams
 
    public static final String PARAM_ANALYZER_CLASS = "analyzer";
 
+   public static final String PARAM_ENABLE_REMOTE_CALLS = "enable-remote-calls";
+
    public static final String PARAM_CHANGES_FILTER_CLASS = "changesfilter-class";
 
    public static final String PARAM_REINDEXING_PAGE_SIZE = "reindexing-page-size";

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/NodeImpl.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/NodeImpl.java
@@ -623,11 +623,11 @@ public class NodeImpl extends ItemImpl implements ExtendedNode
       for (int i = 0; i < mixinTypes.length; i++)
       {
          InternalQName cn = mixinTypes[i];
-         newMixin.add(cn);
          values.add(new TransientValueData(cn));
+         newMixin.add(cn);
       }
-      newMixin.add(type.getName());
       values.add(new TransientValueData(type.getName()));
+      newMixin.add(type.getName());
 
       PropertyData prop =
          (PropertyData)dataManager.getItemData(((NodeData)getData()), new QPathEntry(Constants.JCR_MIXINTYPES, 0),

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/DefaultChangesFilter.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/DefaultChangesFilter.java
@@ -55,22 +55,54 @@ public class DefaultChangesFilter extends IndexerChangesFilter
     */
    public DefaultChangesFilter(SearchManager searchManager, SearchManager parentSearchManager,
       QueryHandlerEntry config, IndexingTree indexingTree, IndexingTree parentIndexingTree, QueryHandler handler,
-      QueryHandler parentHandler, ConfigurationManager cfm) throws IOException, RepositoryConfigurationException,
-      RepositoryException
-   {
+      QueryHandler parentHandler, ConfigurationManager cfm) throws Exception {
       super(searchManager, parentSearchManager, config, indexingTree, parentIndexingTree, handler, parentHandler, cfm);
       IndexerIoModeHandler modeHandler = new IndexerIoModeHandler(IndexerIoMode.READ_WRITE);
       handler.setIndexerIoModeHandler(modeHandler);
       parentHandler.setIndexerIoModeHandler(modeHandler);
 
-      if (!parentHandler.isInitialized())
-      {
-         parentHandler.init();
+      init();
+   }
+
+    /**
+     * @param searchManager
+     * @param parentSearchManager
+     * @param config
+     * @param indexingTree
+     * @param parentIndexingTree
+     * @param handler
+     * @param parentHandler
+     * @param init
+     * @throws IOException
+     * @throws RepositoryConfigurationException
+     * @throws RepositoryException
+     */
+    public DefaultChangesFilter(SearchManager searchManager,
+                                SearchManager parentSearchManager,
+                                QueryHandlerEntry config,
+                                IndexingTree indexingTree,
+                                IndexingTree parentIndexingTree,
+                                QueryHandler handler,
+                                QueryHandler parentHandler,
+                                ConfigurationManager cfm,
+                                boolean init) throws Exception {
+      super(searchManager, parentSearchManager, config, indexingTree, parentIndexingTree, handler, parentHandler, cfm);
+      IndexerIoModeHandler modeHandler = new IndexerIoModeHandler(IndexerIoMode.READ_WRITE);
+      handler.setIndexerIoModeHandler(modeHandler);
+      parentHandler.setIndexerIoModeHandler(modeHandler);
+  
+      if (init) {
+        init();
       }
-      if (!handler.isInitialized())
-      {
-         handler.init();
-      }
+    }
+
+    public void init() throws Exception {
+     if (!parentHandler.isInitialized()) {
+        parentHandler.init();
+     }
+     if (!handler.isInitialized()) {
+        handler.init();
+     }
    }
 
    /**

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/IndexRecovery.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/IndexRecovery.java
@@ -88,4 +88,12 @@ public interface IndexRecovery
     * Frees resources associated with index recovery.
     */
    public void close();
+
+   /**
+    * 
+    * @return An {@link InputStream} of retrieved file from coordinator
+    * 
+    * @throws RepositoryException when an error occurs while retrieving data
+    */
+  InputStream getIndexFolderInZip() throws RepositoryException;
 }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/QueryHandlerContext.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/QueryHandlerContext.java
@@ -73,6 +73,8 @@ public class QueryHandlerContext
    private final boolean createInitialIndex;
 
    private final boolean recoveryFilterUsed;
+   
+   private final boolean enableRemoteCalls;
 
    private final LuceneVirtualTableResolver virtualTableResolver;
 
@@ -120,26 +122,67 @@ public class QueryHandlerContext
       NodeTypeDataManager nodeTypeDataManager, NamespaceRegistryImpl nsRegistry, QueryHandler parentHandler,
       String indexDirectory, DocumentReaderService extractor, boolean createInitialIndex,
       boolean useIndexRecoveryFilters, LuceneVirtualTableResolver virtualTableResolver, IndexRecovery indexRecovery,
-      RPCService rpcService, String repositoryName, String workspaceName, FileCleanerHolder cleanerHolder)
+      RPCService rpcService, String repositoryName, String workspaceName, FileCleanerHolder cleanerHolder)   {
+    this(container,
+         stateMgr,
+         indexingTree,
+         nodeTypeDataManager,
+         nsRegistry,
+         parentHandler,
+         indexDirectory,
+         extractor,
+         createInitialIndex,
+         useIndexRecoveryFilters,
+         true,
+         virtualTableResolver,
+         indexRecovery,
+         rpcService,
+         repositoryName,
+         workspaceName,
+         cleanerHolder);
+   }
+
+   /**
+    * Creates a new context instance.
+    * 
+    * @param stateMgr
+    *            provides persistent item states.
+    * @param nsRegistry
+    *            the namespace registry.
+    * @param parentHandler
+    *            the parent query handler or <code>null</code> it there is no
+    *            parent handler.
+    * @param virtualTableResolver
+    * @param indexRecovery
+    *            the index retriever from other place     
+    * @param rpcService
+    *            RPCService intance if any
+    */
+   public QueryHandlerContext(WorkspaceContainerFacade container, ItemDataConsumer stateMgr, IndexingTree indexingTree,
+                              NodeTypeDataManager nodeTypeDataManager, NamespaceRegistryImpl nsRegistry, QueryHandler parentHandler,
+                              String indexDirectory, DocumentReaderService extractor, boolean createInitialIndex,
+                              boolean useIndexRecoveryFilters, boolean enableRemoteCalls, LuceneVirtualTableResolver virtualTableResolver, IndexRecovery indexRecovery,
+                              RPCService rpcService, String repositoryName, String workspaceName, FileCleanerHolder cleanerHolder)
    {
-      this.indexRecovery = indexRecovery;
-      this.container = container;
-      this.stateMgr = stateMgr;
-      this.indexingTree = indexingTree;
-      this.nodeTypeDataManager = nodeTypeDataManager;
-      this.nsRegistry = nsRegistry;
-      this.indexDirectory = indexDirectory;
-      this.extractor = extractor;
-      this.createInitialIndex = createInitialIndex;
-      this.virtualTableResolver = virtualTableResolver;
-      this.propRegistry = new PropertyTypeRegistry(nodeTypeDataManager);
-      this.rpcService = rpcService;
-      this.parentHandler = parentHandler;
-      this.repositoryName = repositoryName;
-      this.workspaceName = workspaceName;
-      this.recoveryFilterUsed = useIndexRecoveryFilters;
-      this.nodeTypeDataManager.addListener(propRegistry);
-      this.cleanerHolder = cleanerHolder;
+     this.indexRecovery = indexRecovery;
+     this.container = container;
+     this.stateMgr = stateMgr;
+     this.indexingTree = indexingTree;
+     this.nodeTypeDataManager = nodeTypeDataManager;
+     this.nsRegistry = nsRegistry;
+     this.indexDirectory = indexDirectory;
+     this.extractor = extractor;
+     this.createInitialIndex = createInitialIndex;
+     this.virtualTableResolver = virtualTableResolver;
+     this.propRegistry = new PropertyTypeRegistry(nodeTypeDataManager);
+     this.rpcService = rpcService;
+     this.parentHandler = parentHandler;
+     this.repositoryName = repositoryName;
+     this.workspaceName = workspaceName;
+     this.recoveryFilterUsed = useIndexRecoveryFilters;
+     this.nodeTypeDataManager.addListener(propRegistry);
+     this.cleanerHolder = cleanerHolder;
+     this.enableRemoteCalls = enableRemoteCalls;
    }
 
    /**
@@ -301,5 +344,9 @@ public class QueryHandlerContext
    public FileCleanerHolder getCleanerHolder()
    {
       return cleanerHolder;
+   }
+
+   public boolean isEnableRemoteCalls() {
+      return enableRemoteCalls;
    }
 }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/IndexMerger.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/IndexMerger.java
@@ -309,8 +309,9 @@ class IndexMerger extends Thread implements IndexListener
             }
             catch (InterruptedException e)
             {
-               Thread.interrupted();
-               log.warn("Unable to acquire mergerIdle sync");
+               mergerIdle.release();
+               Thread.currentThread().interrupt();
+               return;
             }
          }
 

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/MultiIndex.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/MultiIndex.java
@@ -24,6 +24,8 @@ import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermDocs;
 import org.apache.lucene.store.Directory;
+import org.jboss.util.file.Files;
+
 import org.exoplatform.commons.utils.PrivilegedFileHelper;
 import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.jcr.config.RepositoryConfigurationException;
@@ -2138,43 +2140,56 @@ public class MultiIndex implements IndexerIoModeListener, IndexUpdateMonitorList
    private void createIndex(final NodeDataIndexingIterator iterator, NodeData rootNode, final AtomicLong count,
       final AtomicLong processed) throws RepositoryException, InterruptedException, IOException
    {
-      for (NodeDataIndexing node : iterator.next())
-      {
-         processed.incrementAndGet();
-         if (stopped.get() || Thread.interrupted())
-         {
-            throw new InterruptedException();
-         }
-
-         if (indexingTree.isExcluded(node))
-         {
-            continue;
-         }
-
-         if (!node.getQPath().isDescendantOf(rootNode.getQPath()) && !node.getQPath().equals(rootNode.getQPath()))
-         {
-            continue;
-         }
-
-         executeAndLog(new AddNode(getTransactionId(), node, true));
-         if (count.incrementAndGet() % 1000 == 0)
-         {
-            if (nodesCount == null)
-            {
-               LOG.info("indexing... {} ({})", node.getQPath().getAsString(), count.get());
-            }
-            else
-            {
-               DecimalFormat format = new DecimalFormat("###.#");
-               LOG.info("indexing... {} ({}%)", node.getQPath().getAsString(),
-                  format.format(Math.min(100d * processed.get() / nodesCount.get(), 100)));
-            }
-         }
-
-         synchronized (this)
-         {
-            checkVolatileCommit();
-         }
+      while (iterator.hasNext()) {
+        List<NodeDataIndexing> nodes;
+        try {
+          nodes = iterator.next();
+        } catch (Exception e) {
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Error reading node data indexing, ignore it", e);
+          } else {
+            LOG.warn("Error reading node data indexing, ignore it: {}", e.getMessage());
+          }
+          continue;
+        }
+        for (NodeDataIndexing node : nodes)
+        {
+           processed.incrementAndGet();
+           if (stopped.get() || Thread.interrupted())
+           {
+              throw new InterruptedException();
+           }
+  
+           if (indexingTree.isExcluded(node))
+           {
+              continue;
+           }
+  
+           if (!node.getQPath().isDescendantOf(rootNode.getQPath()) && !node.getQPath().equals(rootNode.getQPath()))
+           {
+              continue;
+           }
+  
+           executeAndLog(new AddNode(getTransactionId(), node, true));
+           if (count.incrementAndGet() % 1000 == 0)
+           {
+              if (nodesCount == null)
+              {
+                 LOG.info("indexing... {} ({})", node.getQPath().getAsString(), count.get());
+              }
+              else
+              {
+                 DecimalFormat format = new DecimalFormat("###.#");
+                 LOG.info("indexing... {} ({}%)", node.getQPath().getAsString(),
+                    format.format(Math.min(100d * processed.get() / nodesCount.get(), 100)));
+              }
+           }
+  
+           synchronized (this)
+           {
+              checkVolatileCommit();
+           }
+        }
       }
    }
 
@@ -3881,36 +3896,42 @@ public class MultiIndex implements IndexerIoModeListener, IndexUpdateMonitorList
       {
          IndexRecovery indexRecovery = handler.getContext().getIndexRecovery();
          // check if index not ready
-         if (!indexRecovery.checkIndexReady())
-         {
+         if (!indexRecovery.checkIndexReady()) {
             return false;
          }
-         //Switch index offline
-         indexRecovery.setIndexOffline();
 
-         for (String filePath : indexRecovery.getIndexList())
-         {
-            File indexFile = new File(indexDirectory, filePath);
-            if (!PrivilegedFileHelper.exists(indexFile.getParentFile()))
-            {
-               PrivilegedFileHelper.mkdirs(indexFile.getParentFile());
-            }
-
-            // transfer file 
-            InputStream in = indexRecovery.getIndexFile(filePath);
-            OutputStream out = PrivilegedFileHelper.fileOutputStream(indexFile);
-            try
-            {
-               DirectoryHelper.transfer(in, out);
-            }
-            finally
-            {
-               DirectoryHelper.safeClose(in);
-               DirectoryHelper.safeClose(out);
-            }
+         if(handler.getContext().isEnableRemoteCalls()) {
+           //Switch index offline
+           indexRecovery.setIndexOffline();
          }
-         //Switch index online
-         indexRecovery.setIndexOnline();
+         long start = System.currentTimeMillis();
+         try {
+           File zipIndexesFile = new File(indexDirectory, "index-recovery-coordinator.zip");
+           if (!PrivilegedFileHelper.exists(zipIndexesFile.getParentFile())) {
+             PrivilegedFileHelper.mkdirs(zipIndexesFile.getParentFile());
+           }
+           // transfer file
+           InputStream in = indexRecovery.getIndexFolderInZip();
+           OutputStream out = PrivilegedFileHelper.fileOutputStream(zipIndexesFile);
+           try {
+             DirectoryHelper.transfer(in, out);
+           } finally {
+             DirectoryHelper.safeClose(in);
+             DirectoryHelper.safeClose(out);
+           }
+
+           DirectoryHelper.uncompressDirectory(zipIndexesFile, indexDirectory);
+           if (!Files.delete(zipIndexesFile)) {
+             zipIndexesFile.deleteOnExit();
+           }
+         } finally {
+           long timeSpent = (System.currentTimeMillis() - start) / 1000;
+           LOG.info("End transfering data from coordinator, {} seconds", timeSpent);
+           if(handler.getContext().isEnableRemoteCalls()) {
+             //Switch index online
+             indexRecovery.setIndexOnline();
+           }
+         }
 
          return true;
       }

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/JDBCStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/JDBCStorageConnection.java
@@ -1332,7 +1332,21 @@ public abstract class JDBCStorageConnection extends DBConstants implements Works
                      tempNodeData.properties.put(key, values);
                   }
 
-                  values.add(new ExtendedTempPropertyData(resultSet));
+                  ExtendedTempPropertyData parsedProperty;
+                  try {
+                    parsedProperty = new ExtendedTempPropertyData(resultSet);
+                  } catch (Exception e) {
+                    if (LOG.isDebugEnabled()) {
+                      LOG.error("Error parsing data of property {} of node {}, ignore it", key, tempNodeData.cid, e);
+                    } else {
+                      LOG.error("Error parsing data of property {} of node {}, ignore it. Error: {}",
+                                key,
+                                tempNodeData.cid,
+                                e.getMessage());
+                    }
+                    continue;
+                  }
+                  values.add(parsedProperty);
                }
             }
 

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/CQJDBCStorageConnection.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/storage/jdbc/optimisation/CQJDBCStorageConnection.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.services.jcr.impl.storage.jdbc.optimisation;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.core.ExtendedPropertyType;
@@ -57,12 +59,7 @@ import org.exoplatform.services.log.Log;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.BatchUpdateException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -958,9 +955,18 @@ abstract public class CQJDBCStorageConnection extends JDBCStorageConnection
          }
          else
          {
-            addValueData(cid, i, stream, streamLength, storageId);
+            try {
+              addValueData(cid, i, stream, streamLength, storageId);
+            } catch (SQLIntegrityConstraintViolationException e) {
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("ERROR persisting {} because it has been detected as new while it's an update of value. Path = ", data.getIdentifier(), data.getQPath().getAsString());
+              }
+              if (StringUtils.contains(e.getMessage(), "Duplicate entry")) {
+                updateValueData(cid, i, stream, streamLength, storageId);
+              }
+            }
          }
-      }
+      } 
    }
 
    private void deleteValues(String cid, PropertyData pdata, Set<String> storageDescs, int totalOldValues,
@@ -1422,7 +1428,12 @@ abstract public class CQJDBCStorageConnection extends JDBCStorageConnection
             List<InternalQName> mNames = new ArrayList<InternalQName>();
             for (TempPropertyData mxnb : mixTypes)
             {
-               InternalQName mxn = InternalQName.parse(ValueDataUtil.getString(mxnb.getValueData()));
+               ValueData valueData = mxnb.getValueData();
+               if (valueData == null || valueData.getLength() == 0) {
+                 LOG.warn("A mixin value of {} have an empty value, ignore it", cpid);
+                 continue;
+               }
+               InternalQName mxn = InternalQName.parse(ValueDataUtil.getString(valueData));
                mNames.add(mxn);
 
                if (!privilegeable && Constants.EXO_PRIVILEGEABLE.equals(mxn))

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/util/JCRDateFormat.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/util/JCRDateFormat.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.services.jcr.impl.util;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.commons.utils.ISO8601;
 import org.exoplatform.commons.utils.Tools;
 import org.exoplatform.services.log.ExoLogger;
@@ -117,6 +119,9 @@ public class JCRDateFormat
    {
       try
       {
+         if (StringUtils.isBlank(dateString)) {
+           return null;
+         }
          return ISO8601.parseEx(dateString);
       }
       catch (ParseException e)

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceDataContainer.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/storage/WorkspaceDataContainer.java
@@ -53,6 +53,13 @@ public interface WorkspaceDataContainer extends DataContainer
 
    public static final String LAZY_NODE_ITERATOR_PAGE_SIZE = "lazy-node-iterator-page-size";
 
+   /**
+    * Whether enable RPC calls to suspend/resume all cluster nodes or not
+    */
+   public static final String ENABLE_RPC_SYNC = "enable-rpc-sync";
+
+   public static final boolean RPC_CALLS_ENABLED_DEFAULT = false;
+
    public static final int LAZY_NODE_ITERATOR_PAGE_SIZE_DEFAULT = 100;
 
    public static final int LAZY_NODE_ITERATOR_PAGE_SIZE_MIN = 20;

--- a/exo.jcr.ext.services/pom.xml
+++ b/exo.jcr.ext.services/pom.xml
@@ -47,9 +47,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.exoplatform.kernel</groupId>
-      <artifactId>exo.kernel.commons.test</artifactId>
-      <scope>test</scope>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.jcr</groupId>
@@ -66,6 +71,11 @@
       <artifactId>exo.ws.rest.ext</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.kernel</groupId>
+      <artifactId>exo.kernel.commons.test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.core</groupId>
       <artifactId>exo.core.component.organization.tests</artifactId>
       <classifier>test-sources</classifier>
@@ -77,20 +87,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.wikbook</groupId>
-      <artifactId>wikbook.docbkxstyle</artifactId>
-      <version>${wikbook.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -100,157 +99,10 @@
   </dependencies>
   <build>
     <plugins>
-      <!-- copy images to wikbook src -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>prepare</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${wikbook.target}/src/resources/images</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/wikbook/images</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>
-      <!-- The wikbook maven plugin generates the docbook document from the wiki source -->
-      <plugin>
-        <groupId>org.wikbook</groupId>
-        <artifactId>wikbook.maven</artifactId>
-        <version>${wikbook.version}</version>
-        <executions>
-          <execution>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>transform</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <sourceDirectory>${wikbook.source}/en/en-US</sourceDirectory>
-          <sourceFileName>book.wiki</sourceFileName>
-          <destinationDirectory>${wikbook.target}/src</destinationDirectory>
-          <destinationFileName>index.xml</destinationFileName>
-
-          <emitDoctype>false</emitDoctype>
-          <beforeBookBodyXML><![CDATA[<xi:include href="bookinfo.ext" xmlns:xi="http://www.w3.org/2001/XInclude" />]]></beforeBookBodyXML>
-          <validationMode>lax</validationMode>
-          <syntaxId>confluence/1.0</syntaxId>
-        </configuration>
-      </plugin>
-      <!-- Unpacks the docbook style resources for the docbkx plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>a</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeGroupIds>org.wikbook</includeGroupIds>
-              <includeArtifactIds>wikbook.docbkxstyle</includeArtifactIds>
-              <excludes>META-INF/**</excludes>
-              <outputDirectory>${wikbook.target}/src/resources</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-            <!-- Dockbx plugin that generates content -->
-      <plugin>
-        <groupId>com.agilejava.docbkx</groupId>
-        <artifactId>docbkx-maven-plugin</artifactId>
-        <version>2.0.7</version>
-        <executions>
-          <execution>
-            <id>Generate HTML</id>
-            <goals>
-              <goal>generate-html</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <htmlCustomization>${wikbook.target}/src/resources/xsl/html.xsl</htmlCustomization>
-              <htmlStylesheet>css/html.css</htmlStylesheet>
-              <imgSrcPath>images/</imgSrcPath>
-              <admonGraphicsPath>images/admons/</admonGraphicsPath>
-            </configuration>
-          </execution>
-          <execution>
-            <id>Generate PDF</id>
-            <goals>
-              <goal>generate-pdf</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <foCustomization>${wikbook.target}/src/resources/xsl/fopdf.xsl</foCustomization>
-              <imgSrcPath>${wikbook.target}/src/resources/images/</imgSrcPath>
-              <admonGraphicsPath>${wikbook.target}/src/resources/images/admons/</admonGraphicsPath>
-            </configuration>
-          </execution>
-        </executions>
-        <configuration>
-          <sourceDirectory>${wikbook.target}/src</sourceDirectory>
-          <targetDirectory>${wikbook.target}/output</targetDirectory>
-          <includes>index.xml</includes>
-          <!-- Highlight source code -->
-          <highlightSource>1</highlightSource>
-          <!-- We need to support xinclude -->
-          <xincludeSupported>true</xincludeSupported>
-          <!--
-           |  See http://www.sagehill.net/docbookxsl/AnnotateListing.html
-           |  Callouts on imported text
-          -->
-          <useExtensions>1</useExtensions>
-          <calloutsExtension>1</calloutsExtension>
-
-          <!-- Copy any docbook XML -->
-          <preProcess>
-            <copy todir="${wikbook.target}/src">
-              <fileset dir="${wikbook.source}/en/en-US">
-                <include name="**/*.ext" />
-              </fileset>
-              <fileset dir="${wikbook.source}/en/en-US">
-                <include name="**/*.xml" />
-              </fileset>
-            </copy>
-          </preProcess>
-
-          <!-- Copy the image for HTML-->
-          <postProcess>
-            <copy todir="${wikbook.target}/output">
-              <fileset dir="${wikbook.target}/src/resources">
-                <include name="**/*.css" />
-                <include name="**/*.png" />
-                <include name="**/*.gif" />
-                <include name="**/*.jpg" />
-                <include name="**/*.jpeg" />
-              </fileset>
-            </copy>
-          </postProcess>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.docbook</groupId>
-            <artifactId>docbook-xml</artifactId>
-            <version>4.4</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
-      </plugin>
-
       <!-- Unpacking Organization Service TCK tests-->
       <plugin>
          <groupId>org.apache.maven.plugins</groupId>
@@ -277,12 +129,10 @@
             </execution>
          </executions>
       </plugin>
-
       <!-- Adding Organization Service TCK resources and test sources-->
       <plugin>
          <groupId>org.codehaus.mojo</groupId>
          <artifactId>build-helper-maven-plugin</artifactId>
-         <version>1.3</version>
          <executions>
             <execution>
                <id>add-test-resource</id>
@@ -322,6 +172,7 @@
               <include>org/exoplatform/services/tck/organization/Test*.java</include>
               <include>org/exoplatform/services/jcr/ext/organization/Test*.java</include>
               <include>org/exoplatform/services/jcr/ext/audit/*Test.java</include>
+              <include>org/exoplatform/services/jcr/ext/index/persistent/*Test.java</include>
           </includes>
           <excludes>
              <exclude>org/exoplatform/services/tck/organization/AbstractOrganizationServiceTest.java</exclude>

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/JCRIndexingOperationType.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/JCRIndexingOperationType.java
@@ -1,0 +1,21 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent;
+
+public enum JCRIndexingOperationType {
+  CREATE, UPDATE, DELETE, REINDEX_ALL, DELETE_ALL
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/JCRIndexingQueueDAO.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/JCRIndexingQueueDAO.java
@@ -1,0 +1,36 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.api;
+
+import java.util.List;
+
+import org.exoplatform.commons.api.persistence.GenericDAO;
+import org.exoplatform.services.jcr.ext.index.persistent.entity.JCRIndexQueueEntity;
+
+public interface JCRIndexingQueueDAO extends GenericDAO<JCRIndexQueueEntity, Long> {
+
+  List<JCRIndexQueueEntity> findAllOperationNotExecutedByClusterNode(int offset, int limit, String clusterNodeName);
+
+  List<JCRIndexQueueEntity> findAllOperationExecutedByClusterNode(String oldClusterNodeName,
+                                                                  String clusterNodeName,
+                                                                  long lastExecutedId,
+                                                                  int offset,
+                                                                  int limit);
+
+  void deleteOperationsByJCRUUID(String removeNodeUUID);
+
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/JCRIndexingService.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/JCRIndexingService.java
@@ -1,0 +1,67 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.api;
+
+import java.util.Set;
+
+import org.exoplatform.services.jcr.config.QueryHandlerEntry;
+import org.exoplatform.services.jcr.impl.core.query.ChangesFilterListsWrapper;
+import org.exoplatform.services.jcr.impl.core.query.QueryHandler;
+
+public interface JCRIndexingService {
+
+  /**
+   * 1/ Read from Queue <br>
+   * 2/ Index in JCR <br>
+   * 3/ Update Queue to mark operation as executed for this node
+   * 
+   * @throws Exception
+   */
+  void processIndexingQueue() throws Exception; // NOSONAR
+
+  /**
+   * JCR Index Changes applied on JCR to propagate for other nodes through Queue
+   * 
+   * @param changes
+   * @param workspaceId REPOSITORY_WORKSPACE
+   */
+  void applyIndexChangesOnQueue(ChangesFilterListsWrapper changes, String workspaceId);
+
+  /**
+   * JCR Index Changes applied on JCR to propagate for other nodes through Queue
+   * 
+   * @param removedNodes removed nodes JCR UUID
+   * @param addedNodes added nodes JCR UUID
+   * @param parentRemovedNodes removed Parent JCR nodes UUID
+   * @param parentAddedNodes added Parent JCR nodes UUID
+   * @param workspaceId REPOSITORY_WORKSPACE
+   */
+  void applyIndexChangesOnQueue(Set<String> removedNodes,
+                                Set<String> addedNodes,
+                                Set<String> parentRemovedNodes,
+                                Set<String> parentAddedNodes,
+                                String workspaceId);
+
+  /**
+   * Initialize JCR Indexing Service
+   * 
+   * @param handler
+   * @param config
+   */
+  void init(QueryHandler handler, QueryHandlerEntry config);
+
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/TransientQueueEntrySet.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/api/TransientQueueEntrySet.java
@@ -1,0 +1,84 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.api;
+
+import java.util.Set;
+
+public class TransientQueueEntrySet {
+  private String      workspace;
+
+  private Set<String> removedNodes;
+
+  private Set<String> addedNodes;
+
+  private Set<String> parentRemovedNodes;
+
+  private Set<String> parentAddedNodes;
+
+  public TransientQueueEntrySet(String workspace,
+                                Set<String> removedNodes,
+                                Set<String> addedNodes,
+                                Set<String> parentRemovedNodes,
+                                Set<String> parentAddedNodes) {
+    this.workspace = workspace;
+    this.removedNodes = removedNodes;
+    this.addedNodes = addedNodes;
+    this.parentRemovedNodes = parentRemovedNodes;
+    this.parentAddedNodes = parentAddedNodes;
+  }
+
+  public String getWorkspace() {
+    return workspace;
+  }
+
+  public void setWorkspace(String workspace) {
+    this.workspace = workspace;
+  }
+
+  public Set<String> getRemovedNodes() {
+    return removedNodes;
+  }
+
+  public void setRemovedNodes(Set<String> removedNodes) {
+    this.removedNodes = removedNodes;
+  }
+
+  public Set<String> getAddedNodes() {
+    return addedNodes;
+  }
+
+  public void setAddedNodes(Set<String> addedNodes) {
+    this.addedNodes = addedNodes;
+  }
+
+  public Set<String> getParentRemovedNodes() {
+    return parentRemovedNodes;
+  }
+
+  public void setParentRemovedNodes(Set<String> parentRemovedNodes) {
+    this.parentRemovedNodes = parentRemovedNodes;
+  }
+
+  public Set<String> getParentAddedNodes() {
+    return parentAddedNodes;
+  }
+
+  public void setParentAddedNodes(Set<String> parentAddedNodes) {
+    this.parentAddedNodes = parentAddedNodes;
+  }
+
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/entity/JCRIndexQueueEntity.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/entity/JCRIndexQueueEntity.java
@@ -1,0 +1,153 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.entity;
+
+import java.util.*;
+
+import javax.persistence.*;
+
+import org.exoplatform.commons.api.persistence.ExoEntity;
+import org.exoplatform.services.jcr.ext.index.persistent.JCRIndexingOperationType;
+
+@Entity(name = "JCRIndexingQueue")
+@ExoEntity
+@Table(name = "JCR_INDEXING_QUEUE")
+@NamedQueries(
+  {
+      @NamedQuery(
+          name = "JCRIndexingQueue.findAllOperationNotExecutedByClusterNode",
+          query = "SELECT idx FROM JCRIndexingQueue idx"
+              + " WHERE :clusterNodeName NOT MEMBER OF idx.nodes"
+              + " ORDER BY idx.modificationDate ASC"
+      ),
+      @NamedQuery(
+          name = "JCRIndexingQueue.findAllOperationNotExecutedByClusterNodePreceedingAnID",
+          query = "SELECT idx FROM JCRIndexingQueue idx"
+              + " WHERE idx.id < :lastExecutedId "
+              + " AND :oldClusterNodeName MEMBER OF idx.nodes"
+              + " AND :clusterNodeName NOT MEMBER OF idx.nodes"
+              + " ORDER BY idx.id ASC"
+      ),
+      @NamedQuery(
+          name = "JCRIndexingQueue.deleteAllIndexingOperationsSince",
+          query = "Delete FROM JCRIndexingQueue idx WHERE idx.id < :id"
+      ),
+      @NamedQuery(
+          name = "JCRIndexingQueue.deleteOperationsByJCRUUID",
+          query = "Delete FROM JCRIndexingQueue idx WHERE idx.jcrUUID = :jcrUUID"
+      )
+  }
+)
+public class JCRIndexQueueEntity {
+  @Id
+  @Column(name = "INDEXING_QUEUE_ID")
+  @SequenceGenerator(name = "SEQ_JCR_INDEXING_QUEUE", sequenceName = "SEQ_JCR_INDEXING_QUEUE")
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_JCR_INDEXING_QUEUE")
+  private long                     id;
+
+  @Column(name = "JCR_UUID", nullable = false)
+  private String                   jcrUUID;
+
+  @Column(name = "WORKSPACE", nullable = false)
+  private String                   workspace;
+
+  @Column(name = "OPERATION_TYPE", nullable = false)
+  private JCRIndexingOperationType operationType;
+
+  @Column(name = "MODIFICATION_DATE", nullable = false)
+  private Calendar                 modificationDate;
+
+  @Column(name = "IS_PARENT_CHANGE", nullable = false)
+  private boolean                  parentChange;
+
+  @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
+  @CollectionTable(name = "JCR_INDEXING_QUEUE_NODES", joinColumns = @JoinColumn(name = "INDEXING_QUEUE_ID"))
+  @Column(name = "NODE_NAME", nullable = false)
+  private Set<String>              nodes;
+
+  public JCRIndexQueueEntity() {
+  }
+
+  public JCRIndexQueueEntity(String jcrUUID,
+                             String workspaceName,
+                             JCRIndexingOperationType operationType,
+                             Calendar modificationDate,
+                             boolean parentChange,
+                             String nodeName) {
+    this.jcrUUID = jcrUUID;
+    this.workspace = workspaceName;
+    this.operationType = operationType;
+    this.modificationDate = modificationDate;
+    this.parentChange = parentChange;
+    addNode(nodeName);
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getJcrUUID() {
+    return jcrUUID;
+  }
+
+  public void setJcrUUID(String jcrUUID) {
+    this.jcrUUID = jcrUUID;
+  }
+
+  public JCRIndexingOperationType getOperationType() {
+    return operationType;
+  }
+
+  public void setOperationType(JCRIndexingOperationType operationType) {
+    this.operationType = operationType;
+  }
+
+  public Calendar getModificationDate() {
+    return modificationDate;
+  }
+
+  public void setModificationDate(Calendar modificationDate) {
+    this.modificationDate = modificationDate;
+  }
+
+  public String getWorkspace() {
+    return workspace;
+  }
+
+  public void setWorkspace(String workspace) {
+    this.workspace = workspace;
+  }
+
+  public boolean isParentChange() {
+    return parentChange;
+  }
+
+  public void setParentChange(boolean parentChange) {
+    this.parentChange = parentChange;
+  }
+
+  public Set<String> getNodes() {
+    return nodes;
+  }
+
+  public void addNode(String nodeName) {
+    if (this.nodes == null) {
+      this.nodes = new HashSet<>();
+    }
+    this.nodes.add(nodeName);
+  }
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/filter/PersistentIndexChangesFilter.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/filter/PersistentIndexChangesFilter.java
@@ -1,0 +1,86 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.filter;
+
+import java.util.Set;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.services.jcr.config.QueryHandlerEntry;
+import org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingService;
+import org.exoplatform.services.jcr.impl.core.query.*;
+
+public class PersistentIndexChangesFilter extends DefaultChangesFilter implements LocalIndexMarker {
+
+  private JCRIndexingService jcrIndexingQueueService;
+
+  public PersistentIndexChangesFilter(SearchManager searchManager,
+                                      SearchManager parentSearchManager,
+                                      QueryHandlerEntry config,
+                                      IndexingTree indexingTree,
+                                      IndexingTree parentIndexingTree,
+                                      QueryHandler handler,
+                                      QueryHandler parentHandler,
+                                      ConfigurationManager cfm)
+      throws Exception {
+    super(searchManager, parentSearchManager, config, indexingTree, parentIndexingTree, handler, parentHandler, cfm, false);
+
+    getJcrIndexingQueueService().init(handler, config);
+
+    super.init();
+  }
+
+  /**
+   * Update JCR indexes and add JCR indexing operations in QUEUE {@inheritDoc}
+   */
+  @Override
+  protected void doUpdateIndex(Set<String> removedNodes,
+                               Set<String> addedNodes,
+                               Set<String> parentRemovedNodes,
+                               Set<String> parentAddedNodes) {
+    try {
+      getJcrIndexingQueueService().processIndexingQueue();
+    } catch (Exception e) {
+      throw new IllegalStateException("An error occurred while indexing from queue before applying Index changes", e);
+    }
+    super.doUpdateIndex(removedNodes, addedNodes, parentRemovedNodes, parentAddedNodes);
+    getJcrIndexingQueueService().applyIndexChangesOnQueue(removedNodes,
+                                                          addedNodes,
+                                                          parentRemovedNodes,
+                                                          parentAddedNodes,
+                                                          getSearchManager().getWsId());
+  }
+
+  @Override
+  protected void doUpdateIndex(final ChangesFilterListsWrapper changes) {
+    try {
+      getJcrIndexingQueueService().processIndexingQueue();
+    } catch (Exception e) {
+      throw new IllegalStateException("An error occurred while indexing from queue before applying Index changes", e);
+    }
+    super.doUpdateIndex(changes);
+    getJcrIndexingQueueService().applyIndexChangesOnQueue(changes, getSearchManager().getWsId());
+  }
+
+  private JCRIndexingService getJcrIndexingQueueService() {
+    if (jcrIndexingQueueService == null) {
+      jcrIndexingQueueService = CommonsUtils.getService(JCRIndexingService.class);
+    }
+    return jcrIndexingQueueService;
+  }
+
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/impl/JCRIndexingQueueDAOImpl.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/impl/JCRIndexingQueueDAOImpl.java
@@ -1,0 +1,63 @@
+/* 
+* Copyright (C) 2003-2020 eXo Platform SAS.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program. If not, see http://www.gnu.org/licenses/ .
+*/
+package org.exoplatform.services.jcr.ext.index.persistent.impl;
+
+import java.util.List;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingQueueDAO;
+import org.exoplatform.services.jcr.ext.index.persistent.entity.JCRIndexQueueEntity;
+
+public class JCRIndexingQueueDAOImpl extends GenericDAOJPAImpl<JCRIndexQueueEntity, Long> implements JCRIndexingQueueDAO {
+
+  @Override
+  @ExoTransactional
+  public List<JCRIndexQueueEntity> findAllOperationNotExecutedByClusterNode(int offset, int limit, String clusterNodeName) {
+    return getEntityManager().createNamedQuery("JCRIndexingQueue.findAllOperationNotExecutedByClusterNode",
+                                               JCRIndexQueueEntity.class)
+                             .setParameter("clusterNodeName", clusterNodeName)
+                             .setFirstResult(offset)
+                             .setMaxResults(limit)
+                             .getResultList();
+  }
+
+  @Override
+  public List<JCRIndexQueueEntity> findAllOperationExecutedByClusterNode(String oldClusterNodeName,
+                                                                         String clusterNodeName,
+                                                                         long lastExecutedId,
+                                                                         int offset,
+                                                                         int limit) {
+    return getEntityManager().createNamedQuery("JCRIndexingQueue.findAllOperationNotExecutedByClusterNodePreceedingAnID",
+                                               JCRIndexQueueEntity.class)
+                             .setParameter("lastExecutedId", lastExecutedId)
+                             .setParameter("oldClusterNodeName", oldClusterNodeName)
+                             .setParameter("clusterNodeName", clusterNodeName)
+                             .setFirstResult(offset)
+                             .setMaxResults(limit)
+                             .getResultList();
+  }
+
+  @Override
+  @ExoTransactional
+  public void deleteOperationsByJCRUUID(String removeNodeUUID) {
+    getEntityManager().createNamedQuery("JCRIndexingQueue.deleteOperationsByJCRUUID")
+                      .setParameter("jcrUUID", removeNodeUUID)
+                      .executeUpdate();
+  }
+
+}

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/impl/JCRIndexingServiceImpl.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/impl/JCRIndexingServiceImpl.java
@@ -1,0 +1,759 @@
+/* 
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/ .
+ */
+package org.exoplatform.services.jcr.ext.index.persistent.impl;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import javax.jcr.RepositoryException;
+import javax.servlet.ServletContext;
+
+import org.apache.commons.lang.StringUtils;
+import org.picocontainer.Startable;
+
+import com.google.api.client.util.IOUtils;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.utils.IOUtil;
+import org.exoplatform.container.*;
+import org.exoplatform.container.RootContainer.PortalContainerPostInitTask;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.*;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.core.WorkspaceContainerFacade;
+import org.exoplatform.services.jcr.ext.index.persistent.JCRIndexingOperationType;
+import org.exoplatform.services.jcr.ext.index.persistent.api.*;
+import org.exoplatform.services.jcr.ext.index.persistent.entity.JCRIndexQueueEntity;
+import org.exoplatform.services.jcr.impl.core.query.*;
+import org.exoplatform.services.jcr.impl.core.query.lucene.ChangesHolder;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.rpc.RPCService;
+
+public class JCRIndexingServiceImpl implements JCRIndexingService, Startable {
+
+  public static final String                                  LAST_OPERATION_FILE_NAME              = "lastOperationID";
+
+  private static final Log                                    LOG                                   =
+                                                                  ExoLogger.getLogger(JCRIndexingServiceImpl.class);
+
+  private static final String                                 CLUSTER_NODE_NAME_PARAMETER           = "cluster.node.name";
+
+  private static final String                                 BATCH_NUMBER_PARAM                    = "batch.number";
+
+  private static final String                                 QUEUE_PROCESSING_PERIOD_SECONDS_PARAM = "queue.periodicity.seconds";
+
+  private final JCRIndexingQueueDAO                           indexingQueueDAO;
+
+  private final RepositoryService                             repositoryService;
+
+  private final EntityManagerService                          entityManagerService;
+
+  private String                                              repositoryName;
+
+  private String                                              clusterNodeName;
+
+  private ThreadLocal<Boolean>                                isIndexingLocally                     = new ThreadLocal<>();
+
+  private int                                                 queueProcessingPeriod                 = 5;
+
+  private final ConcurrentLinkedQueue<TransientQueueEntrySet> transientQueueToPersist               =
+                                                                                      new ConcurrentLinkedQueue<>();
+
+  private ScheduledExecutorService                            filePersisterThread                   =
+                                                                                  Executors.newSingleThreadScheduledExecutor();
+
+  private ScheduledExecutorService                            queueProducingJobService              =
+                                                                                       Executors.newSingleThreadScheduledExecutor();
+
+  private ScheduledExecutorService                            queueConsumingJobService              =
+                                                                                       Executors.newSingleThreadScheduledExecutor();
+
+  private AtomicBoolean                                       indexingOperationIsRunning            = new AtomicBoolean();
+
+  private AtomicLong                                          storedLastOperationId                 = new AtomicLong(0);
+
+  private AtomicLong                                          localLastOperationId                  = null;
+
+  private File                                                localLastOperationFile                = null;
+
+  private int                                                 batchNumber                           = 100;
+
+  private ExoContainer                                        container;
+
+  private boolean                                             initialized;
+
+  public JCRIndexingServiceImpl(EntityManagerService entityManagerService,
+                                RepositoryService repositoryService,
+                                JCRIndexingQueueDAO indexingQueueDAO,
+                                InitParams params) {
+    this.indexingQueueDAO = indexingQueueDAO;
+    this.repositoryService = repositoryService;
+    this.entityManagerService = entityManagerService;
+
+    if (params.containsKey(BATCH_NUMBER_PARAM)) {
+      String batchNumberValue = params.getValueParam(BATCH_NUMBER_PARAM).getValue();
+      try {
+        batchNumber = Integer.parseInt(batchNumberValue);
+      } catch (NumberFormatException e) {
+        LOG.warn("Invalid parameter {} with value {}. default value will be used",
+                 BATCH_NUMBER_PARAM,
+                 batchNumberValue,
+                 batchNumber);
+      }
+    }
+
+    if (params.containsKey(QUEUE_PROCESSING_PERIOD_SECONDS_PARAM)) {
+      String value = params.getValueParam(QUEUE_PROCESSING_PERIOD_SECONDS_PARAM).getValue();
+      try {
+        queueProcessingPeriod = Integer.parseInt(value);
+      } catch (NumberFormatException e) {
+        LOG.warn("Invalid parameter {} with value {}. default value will be used",
+                 QUEUE_PROCESSING_PERIOD_SECONDS_PARAM,
+                 value,
+                 queueProcessingPeriod);
+      }
+    }
+    clusterNodeName =
+                    params.containsKey(CLUSTER_NODE_NAME_PARAMETER) ? params.getValueParam(CLUSTER_NODE_NAME_PARAMETER).getValue()
+                                                                    : null;
+    if (StringUtils.isBlank(clusterNodeName)) {
+      throw new IllegalStateException(CLUSTER_NODE_NAME_PARAMETER + " parameter is empty");
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public synchronized void processIndexingQueue() throws Exception {
+    if (!initialized || isIndexingInCurrentThread()) {
+      return;
+    }
+    isIndexingLocally.set(true);
+    computeCurrentContainer();
+    RequestLifeCycle.begin(entityManagerService);
+    try {
+      applyIndexChangesOnJCR();
+    } finally {
+      isIndexingLocally.remove();
+      RequestLifeCycle.end();
+    }
+  }
+
+  @Override
+  public void start() {
+    if (container instanceof PortalContainer) {
+      PortalContainer portalContainer = (PortalContainer) container;
+      PortalContainer.addInitTask(portalContainer.getPortalContext(), new PortalContainerPostInitTask() {
+        @Override
+        public void execute(ServletContext context, PortalContainer portalContainer) {
+          scheduleIndexTasks();
+        }
+      });
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (!queueProducingJobService.isShutdown() && !queueProducingJobService.isTerminated()) {
+      queueProducingJobService.shutdownNow();
+    }
+    if (!queueConsumingJobService.isShutdown() && !queueConsumingJobService.isTerminated()) {
+      queueConsumingJobService.shutdownNow();
+    }
+    if (!filePersisterThread.isShutdown() && !filePersisterThread.isTerminated()) {
+      filePersisterThread.shutdownNow();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void applyIndexChangesOnQueue(ChangesFilterListsWrapper changes, String workspaceId) {
+    applyIndexChangesOnQueue(changes.getRemovedNodes(),
+                             changes.getAddedNodes(),
+                             changes.getParentRemovedNodes(),
+                             changes.getParentAddedNodes(),
+                             workspaceId);
+  }
+
+  @Override
+  public void applyIndexChangesOnQueue(final Set<String> removedNodes,
+                                       final Set<String> addedNodes,
+                                       final Set<String> parentRemovedNodes,
+                                       final Set<String> parentAddedNodes,
+                                       String workspaceId) {
+    transientQueueToPersist.offer(new TransientQueueEntrySet(workspaceId,
+                                                             removedNodes,
+                                                             addedNodes,
+                                                             parentRemovedNodes,
+                                                             parentAddedNodes));
+  }
+
+  /**
+   * Update Queue, JCR indexes and status file. {@inheritDoc}
+   */
+  @Override
+  public synchronized void init(QueryHandler handler, QueryHandlerEntry config) {
+    if (initialized) {
+      return;
+    }
+
+    LOG.debug("Initialize JCR QUEUE Indexing Service");
+
+    retrieveLocalLastOperationFile();
+    if (this.localLastOperationFile == null || !this.localLastOperationFile.exists()) {
+      try {
+        // Retrieve file from coordinator if it doesn't exist locally
+        // This means that the index folder is empty and we should copy indexes
+        // from coordinator AND update Queue status
+        String indexDirPath = config.getParameter(QueryHandlerParams.PARAM_INDEX_DIR).getValue();
+        retrieveLastOperationIDFromCoordinator(handler, indexDirPath);
+      } catch (Exception e) {
+        LOG.warn("Unable to retrieve lastOperation file from coordinator", e);
+      }
+    }
+
+    // After retrieving index from coordinator, or just starting up, force
+    // update index status of indexes synchronously
+    if (this.localLastOperationFile != null && this.localLastOperationFile.exists()) {
+      // Update Queue with last status if the indexes was manually copied from
+      // coordinator
+      updateQueueSwitchStatusInFile();
+    }
+    initialized = true;
+  }
+
+  /**
+   * Apply the changes coming from queue to JCR. The changes are identitifed by
+   * JCR UUID and Operation type.
+   * 
+   * @param indexingQueueEntities {@link List} of {@link JCRIndexQueueEntity} to
+   *          index
+   * @throws Exception when an error happens while indexing the operation
+   */
+  @ExoTransactional
+  public void applyIndexChangesOnJCR(List<JCRIndexQueueEntity> indexingQueueEntities) throws Exception { // NOSONAR
+    if (indexingQueueEntities == null || indexingQueueEntities.isEmpty()) {
+      return;
+    }
+
+    Map<String, List<JCRIndexQueueEntity>> opByWorkspace = convertEntitiesToMapByWorkspace(indexingQueueEntities);
+    Map<String, Map<Boolean, Map<JCRIndexingOperationType, Set<String>>>> opByWorkspaceByType =
+                                                                                              convertEntitiesToMapByWorkspaceByType(indexingQueueEntities);
+    for (Map.Entry<String, Map<Boolean, Map<JCRIndexingOperationType, Set<String>>>> operationsByTypeEntry : opByWorkspaceByType.entrySet()) {
+      String workspaceId = operationsByTypeEntry.getKey();
+      SearchManager searchManager = getSearchManager(workspaceId);
+      Map<Boolean, Map<JCRIndexingOperationType, Set<String>>> operationsByType = operationsByTypeEntry.getValue();
+
+      Map<JCRIndexingOperationType, Set<String>> parentOpsByType = operationsByType.containsKey(true) ? operationsByType.get(true)
+                                                                                                      : Collections.emptyMap();
+      Map<JCRIndexingOperationType, Set<String>> opsByType = operationsByType.containsKey(false) ? operationsByType.get(false)
+                                                                                                 : Collections.emptyMap();
+      Set<String> parentAddedNodes = getJCRUUIDs(parentOpsByType, JCRIndexingOperationType.CREATE);
+      Set<String> parentRemovedNodes = getJCRUUIDs(parentOpsByType, JCRIndexingOperationType.DELETE);
+
+      Set<String> addedNodes = getJCRUUIDs(opsByType, JCRIndexingOperationType.CREATE);
+      Set<String> removedNodes = getJCRUUIDs(opsByType, JCRIndexingOperationType.DELETE);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("APPLY index to JCR: '{}' parent create & '{}' parent remove & '{}' create & '{}' remove",
+                  parentAddedNodes.size(),
+                  parentRemovedNodes.size(),
+                  addedNodes.size(),
+                  removedNodes.size());
+        for (String parentRemovedNode : parentRemovedNodes) {
+          LOG.debug("-  APPLY index to JCR: parent delete UUID = {}", parentRemovedNode);
+        }
+        for (String removedNode : removedNodes) {
+          LOG.debug("-  APPLY index to JCR: delete UUID = {}", removedNode);
+        }
+        for (String parentAddedNode : parentAddedNodes) {
+          LOG.debug("+  APPLY index to JCR: parent create UUID = {}", parentAddedNode);
+        }
+        for (String addedNode : addedNodes) {
+          LOG.debug("+  APPLY index to JCR: create UUID = {}", addedNode);
+        }
+      }
+
+      ChangesHolder parentChanges = searchManager.getChanges(parentRemovedNodes, parentAddedNodes);
+      ChangesHolder changes = searchManager.getChanges(removedNodes, addedNodes);
+
+      searchManager.apply(parentChanges);
+      searchManager.apply(changes);
+
+      List<JCRIndexQueueEntity> operationsSucceeded = opByWorkspace.get(workspaceId);
+      for (JCRIndexQueueEntity jcrIndexQueueEntity : operationsSucceeded) {
+        jcrIndexQueueEntity.addNode(clusterNodeName);
+        this.updateLastNewOperationId(jcrIndexQueueEntity.getId());
+      }
+      indexingQueueDAO.updateAll(operationsSucceeded);
+    }
+  }
+
+  @ExoTransactional
+  public List<JCRIndexQueueEntity> findNextOperations(int offset, int batchNumber) {
+    return indexingQueueDAO.findAllOperationNotExecutedByClusterNode(offset, batchNumber, clusterNodeName);
+  }
+
+  @ExoTransactional
+  public void index(String jcrUUID, String workspaceId, boolean parentChange) {
+    if (isIndexingInCurrentThread()) {
+      return;
+    }
+    checkIndexingArguments(jcrUUID, workspaceId);
+    JCRIndexQueueEntity indexQueueEntity = addToIndexingQueue(jcrUUID,
+                                                              workspaceId,
+                                                              JCRIndexingOperationType.CREATE,
+                                                              parentChange);
+    updateLastNewOperationId(indexQueueEntity.getId());
+  }
+
+  @ExoTransactional
+  public void reindex(String jcrUUID, String workspaceId, boolean parentChange) {
+    if (isIndexingInCurrentThread()) {
+      return;
+    }
+    checkIndexingArguments(jcrUUID, workspaceId);
+    JCRIndexQueueEntity indexQueueEntity = addToIndexingQueue(jcrUUID,
+                                                              workspaceId,
+                                                              JCRIndexingOperationType.UPDATE,
+                                                              parentChange);
+    updateLastNewOperationId(indexQueueEntity.getId());
+  }
+
+  @ExoTransactional
+  public void unindex(String jcrUUID, String workspaceId, boolean parentChange) {
+    if (isIndexingInCurrentThread()) {
+      return;
+    }
+    checkIndexingArguments(jcrUUID, workspaceId);
+    JCRIndexQueueEntity indexQueueEntity = addToIndexingQueue(jcrUUID,
+                                                              workspaceId,
+                                                              JCRIndexingOperationType.DELETE,
+                                                              parentChange);
+    updateLastNewOperationId(indexQueueEntity.getId());
+  }
+
+  @ExoTransactional
+  public void unindexAll(String workspaceId) {
+    if (isIndexingInCurrentThread()) {
+      return;
+    }
+    checkIndexingArgument("workspaceId", workspaceId);
+    JCRIndexQueueEntity indexQueueEntity = addToIndexingQueue("-", workspaceId, JCRIndexingOperationType.DELETE_ALL, false);
+    updateLastNewOperationId(indexQueueEntity.getId());
+  }
+
+  @ExoTransactional
+  public void updateQueueSwitchStatusInFile() {
+    try {
+      String lastExecutedOperation = getLastExecutedOperation();
+      if (StringUtils.isBlank(lastExecutedOperation)) {
+        return;
+      }
+
+      String[] lastExecutedIdArray = lastExecutedOperation.split(";");
+      String oldClusterNodeName = lastExecutedIdArray[1];
+      String lastExecutedIdString = lastExecutedIdArray[0];
+      if (!this.clusterNodeName.equals(oldClusterNodeName) && StringUtils.isNotBlank(lastExecutedIdString)) {
+        LOG.debug("Start: Update Queue with last status because the indexes was manually copied");
+
+        // If the last executed id was copied with index folder
+        // from coordinator, the QUEUE has to be updated to reflect that
+        // the current copied indexes are applied on currentClusterNode too
+        // And operation id is less than id from file
+        int offset = 0;
+        int proceededOperations = 0;
+        int totalProceededOperations = 0;
+        long lastExecutedId = Long.parseLong(lastExecutedIdString);
+        Long totalIndexingOperations = indexingQueueDAO.count();
+        do {
+          List<JCRIndexQueueEntity> indexingQueueEntities =
+                                                          indexingQueueDAO.findAllOperationExecutedByClusterNode(oldClusterNodeName,
+                                                                                                                 clusterNodeName,
+                                                                                                                 lastExecutedId,
+                                                                                                                 offset,
+                                                                                                                 batchNumber);
+          // Mark all operations as executed for node as well
+          for (JCRIndexQueueEntity jcrIndexQueueEntity : indexingQueueEntities) {
+            jcrIndexQueueEntity.addNode(clusterNodeName);
+          }
+          indexingQueueDAO.updateAll(indexingQueueEntities);
+          proceededOperations = indexingQueueEntities.size();
+          totalProceededOperations += proceededOperations;
+
+          LOG.debug("Retrieved indexes update: {} / {}", totalProceededOperations, totalIndexingOperations);
+        } while (proceededOperations == batchNumber);
+
+        LOG.debug("End: Update Queue with last status because the indexes was manually copied. Total indexes updates: {} / {}",
+                  totalProceededOperations,
+                  totalIndexingOperations);
+
+        updateLastNewOperationId(lastExecutedId);
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Couldn't read file JCR queue indexing last operation id", e);
+    }
+  }
+
+  public String getLastExecutedOperation() {
+    if (localLastOperationFile == null || !localLastOperationFile.exists()) {
+      return null;
+    }
+    try {
+      return IOUtil.getFileContentAsString(localLastOperationFile);
+    } catch (IOException e) {
+      LOG.error("An error occurred while retrieving last operation id from file", e);
+      return null;
+    }
+  }
+
+  public int getQueueProcessingPeriod() {
+    return queueProcessingPeriod;
+  }
+
+  public synchronized void persistQueueOperations() {
+    computeCurrentContainer();
+    while (transientQueueToPersist.peek() != null) {
+      TransientQueueEntrySet queueEntrySet = transientQueueToPersist.poll();
+      Set<String> addedNodes = queueEntrySet.getAddedNodes();
+      Set<String> parentAddedNodes = queueEntrySet.getParentAddedNodes();
+      Set<String> removedNodes = queueEntrySet.getRemovedNodes();
+      Set<String> parentRemovedNodes = queueEntrySet.getParentRemovedNodes();
+      String workspaceId = queueEntrySet.getWorkspace();
+
+      RequestLifeCycle.begin(entityManagerService);
+      try {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("PUSH to queue index: '{}' parent create & '{}' parent remove & '{}' create & '{}' remove",
+                    parentAddedNodes.size(),
+                    parentRemovedNodes.size(),
+                    addedNodes.size(),
+                    removedNodes.size());
+          for (String parentRemovedNode : parentRemovedNodes) {
+            LOG.debug("-  PUSH to queue index: parent delete UUID = {}", parentRemovedNode);
+          }
+          for (String removedNode : removedNodes) {
+            LOG.debug("-  PUSH to queue index: delete UUID = {}", removedNode);
+          }
+          for (String parentAddedNode : parentAddedNodes) {
+            LOG.debug("+  PUSH to queue index: parent create UUID = {}", parentAddedNode);
+          }
+          for (String addedNode : addedNodes) {
+            LOG.debug("+  PUSH to queue index: create UUID = {}", addedNode);
+          }
+        }
+
+        for (String removeNodeUUID : parentRemovedNodes) {
+          if (!parentAddedNodes.contains(removeNodeUUID)) {
+            // 1. First step: This is not an update, the node is deleted, thus
+            // delete all
+            // previous indexing Operations relative to this UUID
+            LOG.debug("Delete all previous indexing operations with JCR UUID '{}' since the node was deleted", removeNodeUUID);
+            indexingQueueDAO.deleteOperationsByJCRUUID(removeNodeUUID);
+          }
+          // 2. Second step: add a new entry in queue to requesting unindexing
+          // this node with its parent
+          unindex(removeNodeUUID, workspaceId, true);
+        }
+        for (String removeNodeUUID : removedNodes) {
+          if (!addedNodes.contains(removeNodeUUID)) {
+            // 1. First step: This is not an update, the node is deleted, thus
+            // delete all
+            // previous indexing Operations relative to this UUID
+            LOG.debug("Delete all previous indexing operations with JCR UUID '{}' since the node was deleted", removeNodeUUID);
+            indexingQueueDAO.deleteOperationsByJCRUUID(removeNodeUUID);
+          }
+          // 2. Second step: add a new entry in queue to requesting unindexing
+          // this node without a change on its parent
+          unindex(removeNodeUUID, workspaceId, false);
+        }
+
+        for (String addedNodeUUID : parentAddedNodes) {
+          index(addedNodeUUID, workspaceId, true);
+        }
+        for (String addedNodeUUID : addedNodes) {
+          index(addedNodeUUID, workspaceId, false);
+        }
+      } catch (Exception e) {
+        LOG.error("Error while applying changes", e);
+      } finally {
+        RequestLifeCycle.end();
+      }
+    }
+  }
+
+  private void retrieveLastOperationIDFromCoordinator(QueryHandler handler, String indexDirPath) throws Exception { // NOSONAR
+    IndexRecovery indexRecovery = handler.getContext().getIndexRecovery();
+
+    File indexDirFile = new File(indexDirPath);
+    File lastOperationFile = new File(indexDirFile.getParentFile(), LAST_OPERATION_FILE_NAME);
+    if (lastOperationFile.exists()) {
+      // If last indexing operation already exists, we will not retrieve the
+      // index folder of workspace from coordinator. In fact, the file could be
+      // already retrieved from coordinator by another workspace initialization
+      this.localLastOperationFile = lastOperationFile;
+      return;
+    }
+
+    if (!handler.getContext().isRecoveryFilterUsed() || handler.getContext().getIndexRecovery() == null) {
+      // Can't retrieve from coordinator if RecoveryFilter is not configured
+      return;
+    }
+
+    RPCService rpcService = handler.getContext().getRPCService();
+    if (rpcService == null || rpcService.isCoordinator()) {
+      // Can't retrieve from coordinator (master) if the started node is the
+      // coordinator (master) itself
+      return;
+    }
+
+    LOG.debug("Retriving last executed queue operation file from coordinator");
+    // Retrieving only the file of last indexed operation
+    InputStream indexFile = indexRecovery.getIndexFile("../" + LAST_OPERATION_FILE_NAME);
+    try (FileOutputStream outputStream = new FileOutputStream(lastOperationFile)) {
+      IOUtils.copy(indexFile, outputStream);
+      outputStream.flush();
+    }
+  }
+
+  private void applyIndexChangesOnJCR() throws Exception {
+    int offset = 0;
+    int proceededOperations = 0;
+    do {
+      List<JCRIndexQueueEntity> indexingQueueEntities = findNextOperations(offset, batchNumber);
+      proceededOperations = indexingQueueEntities.size();
+      applyIndexChangesOnJCR(indexingQueueEntities);
+    } while (proceededOperations == batchNumber);
+  }
+
+  private void updateLastNewOperationId(final long id) {
+    checkStoredLastOperationId();
+    // Update it locally and let it be stored async in sheduled job
+    this.localLastOperationId.getAndUpdate(value -> id > value ? id : value);
+  }
+
+  public void persistLastOperationId() {
+    retrieveLocalLastOperationFile();
+    if (this.localLastOperationFile == null) {
+      LOG.error("JCR Index parent directory wasn't found. Can't save last indexed operation.");
+      return;
+    }
+
+    checkStoredLastOperationId();
+    long id = this.localLastOperationId.get();
+    if (storedLastOperationId.get() >= id) {
+      // No need to store again an id of index operation that was already
+      // executed
+      return;
+    }
+
+    LOG.debug("Persist last index operation id: {}", id);
+    try (FileOutputStream outputStream = new FileOutputStream(this.localLastOperationFile)) {
+
+      String fileContent = id + ";" + clusterNodeName;
+      outputStream.write(fileContent.getBytes());
+      outputStream.flush();
+
+      this.storedLastOperationId.set(id);
+    } catch (Exception e) {
+      LOG.error("Error while writing last operation ID ", e);
+    }
+  }
+
+  private void checkStoredLastOperationId() {
+    if (this.localLastOperationId == null) {
+      String lastExecutedOperation = getLastExecutedOperation();
+      if (StringUtils.isNotBlank(lastExecutedOperation)) {
+        String[] lastExecutedIdArray = lastExecutedOperation.split(";");
+        String lastExecutedIdString = lastExecutedIdArray[0];
+        this.localLastOperationId = new AtomicLong(Long.parseLong(lastExecutedIdString));
+      } else {
+        this.localLastOperationId = new AtomicLong(0);
+      }
+      this.storedLastOperationId.set(this.localLastOperationId.get());
+    }
+  }
+
+  private JCRIndexQueueEntity addToIndexingQueue(String jcrUUID,
+                                                 String workspaceId,
+                                                 JCRIndexingOperationType operationType,
+                                                 boolean parentChange) {
+    if (operationType == null) {
+      throw new IllegalArgumentException("Operation cannot be null");
+    }
+    JCRIndexQueueEntity indexingEntity = getIndexingEntity(jcrUUID, workspaceId, operationType, parentChange);
+    indexingEntity = indexingQueueDAO.create(indexingEntity);
+    return indexingEntity;
+  }
+
+  private boolean isIndexingInCurrentThread() {
+    return this.isIndexingLocally.get() != null && this.isIndexingLocally.get();
+  }
+
+  private JCRIndexQueueEntity getIndexingEntity(String jcrUUID,
+                                                String workspaceId,
+                                                JCRIndexingOperationType operationType,
+                                                boolean parentChange) {
+    return new JCRIndexQueueEntity(jcrUUID, workspaceId, operationType, Calendar.getInstance(), parentChange, clusterNodeName);
+  }
+
+  private void retrieveLocalLastOperationFile() {
+    if (this.localLastOperationFile != null) {
+      return;
+    }
+    String workspaceIndexDirName = getSystemWorkspaceIndexDirectory();
+    if (StringUtils.isBlank(workspaceIndexDirName)) {
+      return;
+    }
+    File workspaceIndexFolder = new File(workspaceIndexDirName);
+    File rootIndexFolder = workspaceIndexFolder.getParentFile();
+    if (!rootIndexFolder.exists()) {
+      rootIndexFolder.mkdirs();
+    }
+    this.localLastOperationFile = new File(rootIndexFolder, LAST_OPERATION_FILE_NAME);
+  }
+
+  private String getSystemWorkspaceIndexDirectory() {
+    String indexDirName = null;
+    try {
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      String systemWorkspaceName = repository.getConfiguration().getSystemWorkspaceName();
+      WorkspaceContainerFacade workspaceContainer = repository.getWorkspaceContainer(systemWorkspaceName);
+      WorkspaceEntry workspaceEntry = (WorkspaceEntry) workspaceContainer.getComponent(WorkspaceEntry.class);
+      indexDirName = workspaceEntry.getQueryHandler().getParameterValue(QueryHandlerParams.PARAM_INDEX_DIR);
+    } catch (Exception e) {
+      LOG.error("Error while getting system workspace configuration");
+    }
+    return indexDirName;
+  }
+
+  private void checkIndexingArguments(String jcrUUID, String workspaceId) {
+    checkIndexingArgument("workspaceId", workspaceId);
+    checkIndexingArgument("jcrUUID", jcrUUID);
+  }
+
+  private void checkIndexingArgument(String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException(name + " is null");
+    }
+  }
+
+  private SearchManager getSearchManager(String workspaceId) throws RepositoryException {
+    if (StringUtils.isBlank(workspaceId)) {
+      throw new IllegalArgumentException("Workspace id is null");
+    }
+    if (!workspaceId.contains(getRepositoryName())) {
+      throw new IllegalArgumentException("Workspace id '" + workspaceId + "' doesn't match pattern '" + getRepositoryName()
+          + "_WORKSPACENAME' ");
+    }
+    String workspaceName = workspaceId.replace(getRepositoryName() + "_", "");
+
+    WorkspaceContainerFacade workspaceContainer = repositoryService.getCurrentRepository().getWorkspaceContainer(workspaceName);
+    if (workspaceContainer == null) {
+      throw new IllegalStateException("Can't find workspace container with name " + workspaceName);
+    }
+    return (SearchManager) workspaceContainer.getComponent(SearchManager.class);
+  }
+
+  private String getRepositoryName() {
+    if (this.repositoryName == null) {
+      try {
+        this.repositoryName = repositoryService.getConfig().getDefaultRepositoryName();
+      } catch (Exception e) {
+        throw new IllegalStateException("Can't get current repository name from repository service", e);
+      }
+    }
+    return repositoryName;
+  }
+
+  private Set<String> getJCRUUIDs(Map<JCRIndexingOperationType, Set<String>> operationsByType,
+                                  JCRIndexingOperationType operationType) {
+    Set<String> nodesUUIDSet = operationsByType.containsKey(operationType) ? operationsByType.get(operationType) : null;
+    if (nodesUUIDSet == null) {
+      nodesUUIDSet = Collections.emptySet();
+    }
+    return nodesUUIDSet;
+  }
+
+  private Map<String, Map<Boolean, Map<JCRIndexingOperationType, Set<String>>>> convertEntitiesToMapByWorkspaceByType(List<JCRIndexQueueEntity> indexingQueueEntities) {
+    return indexingQueueEntities.stream()
+                                .collect(Collectors.groupingBy(JCRIndexQueueEntity::getWorkspace,
+                                                               Collectors.groupingBy(JCRIndexQueueEntity::isParentChange,
+                                                                                     Collectors.groupingBy(JCRIndexQueueEntity::getOperationType,
+                                                                                                           Collectors.mapping(JCRIndexQueueEntity::getJcrUUID,
+                                                                                                                              Collectors.toSet())))));
+  }
+
+  private Map<String, List<JCRIndexQueueEntity>> convertEntitiesToMapByWorkspace(List<JCRIndexQueueEntity> indexingQueueEntities) {
+    return indexingQueueEntities.stream()
+                                .collect(Collectors.groupingBy(JCRIndexQueueEntity::getWorkspace,
+                                                               Collectors.toList()));
+  }
+
+  private void computeCurrentContainer() {
+    if (container == null) {
+      container = ExoContainerContext.getCurrentContainerIfPresent();
+    }
+
+    if (container instanceof RootContainer) {
+      container = PortalContainer.getInstance();
+    }
+    ExoContainerContext.setCurrentContainer(container);
+  }
+
+  private void scheduleIndexTasks() {
+    retrieveLocalLastOperationFile();
+    checkStoredLastOperationId();
+
+    // Job to index operations retrieved from queue and not indexed locally
+    queueConsumingJobService.scheduleAtFixedRate(() -> {
+      if (indexingOperationIsRunning.get()) {
+        LOG.debug("Previous QUEUE indexing processing task is always executing, skip this execution");
+        return;
+      }
+      indexingOperationIsRunning.set(true);
+      computeCurrentContainer();
+      RequestLifeCycle.begin(entityManagerService);
+      try {
+        LOG.debug("Running JCR Index from DB QUEUE Task");
+        processIndexingQueue();
+      } catch (Exception e) {
+        LOG.error("Error while Running JCR nodes indexing operation", e);
+      } finally {
+        indexingOperationIsRunning.set(false);
+        RequestLifeCycle.end();
+      }
+    }, 0, queueProcessingPeriod, TimeUnit.SECONDS);
+
+    // Persist indexing operations made locally
+    queueProducingJobService.scheduleAtFixedRate(() -> persistQueueOperations(), 0, queueProcessingPeriod, TimeUnit.SECONDS);
+
+    // Persist last executed operation id when changed
+    filePersisterThread.scheduleAtFixedRate(() -> persistLastOperationId(), 0, 10, TimeUnit.SECONDS);
+  }
+
+}

--- a/exo.jcr.ext.services/src/main/resources/conf/configuration.xml
+++ b/exo.jcr.ext.services/src/main/resources/conf/configuration.xml
@@ -16,25 +16,17 @@
       <values-param profiles="cluster">
         <name>properties.urls</name>
         <value>jar:/conf/jcr-cluster.properties</value>
-        <value>jar:/conf/jcr-cluster-udp.properties</value>
-        <!-- load this at last to reuse properties from upper files -->
-        <value>jar:/conf/jcr.properties</value>
-      </values-param>
-      <values-param profiles="cluster-jgroups-tcp">
-        <name>properties.urls</name>
-        <value>jar:/conf/jcr-cluster.properties</value>
         <value>jar:/conf/jcr-cluster-tcp.properties</value>
         <!-- load this at last to reuse properties from upper files -->
         <value>jar:/conf/jcr.properties</value>
       </values-param>
-      <!-- DEPRECATED JCR index clustering strategy -->
-      <properties-param profiles="cluster-index-shared">
-        <name>ChangeFilterClass</name>
-        <description>Filter used to notify changes in the jcr index in cluster</description>
-        <property name="gatein.jcr.index.changefilterclass" value="org.exoplatform.services.jcr.impl.core.query.ispn.ISPNIndexChangesFilter" />
-        <!-- Use this lock factory to lock index files on cluster wide -->
-        <property name="org.exoplatform.jcr.lucene.store.FSDirectoryLockFactoryClass" value="org.apache.lucene.store.NativeFSLockFactory" />
-      </properties-param>
+      <values-param profiles="cluster-jgroups-udp">
+        <name>properties.urls</name>
+        <value>jar:/conf/jcr-cluster.properties</value>
+        <value>jar:/conf/jcr-cluster-udp.properties</value>
+        <!-- load this at last to reuse properties from upper files -->
+        <value>jar:/conf/jcr.properties</value>
+      </values-param>
     </init-params>
   </component>
 
@@ -57,4 +49,21 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins profiles="cluster">
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>CommonsChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of commons</description>
+          <value>db/changelog/jcr-index.db.changelog-1.0.0.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/exo.jcr.ext.services/src/main/resources/conf/jcr-cluster.properties
+++ b/exo.jcr.ext.services/src/main/resources/conf/jcr-cluster.properties
@@ -1,4 +1,4 @@
 exo.jcr.cache.config=jar:/conf/jcr/cache/cluster/cache-config.xml
 exo.jcr.lock.cache.config=jar:/conf/jcr/cache/cluster/lock-config.xml
 exo.jcr.index.cache.config=jar:/conf/jcr/cache/cluster/indexer-config.xml
-gatein.jcr.index.changefilterclass=org.exoplatform.services.jcr.impl.core.query.ispn.LocalIndexChangesFilter
+gatein.jcr.index.changefilterclass=org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter

--- a/exo.jcr.ext.services/src/main/resources/conf/portal/configuration.xml
+++ b/exo.jcr.ext.services/src/main/resources/conf/portal/configuration.xml
@@ -20,6 +20,35 @@
     <type>org.exoplatform.services.jcr.ext.resource.representation.NtResourceNodeRepresentationFactory</type>
   </component>
 
+  <component profiles="cluster">
+    <key>org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingQueueDAO</key>
+    <type>org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingQueueDAOImpl</type>
+  </component>
+
+  <component profiles="cluster">
+    <key>org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingService</key>
+    <type>org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingServiceImpl</type>
+    <init-params>
+      <value-param>
+        <name>cluster.node.name</name>
+        <description>Cluster node name</description>
+        <value>${exo.cluster.node.name:}</value>
+      </value-param>
+      <value-param>
+        <name>batch.number</name>
+        <description>Batching count when processing elements from queue
+        after retrieving indexes from coordinator/master</description>
+        <value>${exo.jcr.indexing.persistent.queue.batch.number:100}</value>
+      </value-param>
+      <value-param>
+        <name>queue.periodicity.seconds</name>
+        <description>Periodicity of asunchronous queue processing
+        to index nodes that has changes made by other Cluster nodes</description>
+        <value>${exo.jcr.indexing.persistent.queue.periodicity.seconds:5}</value>
+      </value-param>
+    </init-params>
+  </component>
+
   <external-component-plugins>
     <target-component>org.exoplatform.services.jcr.RepositoryService</target-component>
     <component-plugin>

--- a/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
+++ b/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+  <property name="autoIncrement" value="true" dbms="mysql,mssql,h2,hsqldb"/>
+  <property name="autoIncrement" value="false" dbms="oracle,postgresql"/>
+
+  <!-- JCR Index Queue -->
+  <changeSet author="jcr-index" id="1.0.0-1" dbms="oracle,postgresql">
+    <createSequence sequenceName="SEQ_JCR_INDEXING_QUEUE" startValue="1"/>
+  </changeSet>
+  <changeSet author="jcr-index" id="1.0.0-2">
+    <createTable tableName="JCR_INDEXING_QUEUE">
+      <column name="INDEXING_QUEUE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_JCR_INDEXING_QUEUE_ID"/>
+      </column>
+      <column name="JCR_UUID" type="NVARCHAR(70)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="WORKSPACE" type="NVARCHAR(30)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="OPERATION_TYPE" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="IS_PARENT_CHANGE" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="MODIFICATION_DATE" type="TIMESTAMP(3)" >
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <modifySql dbms="mysql">
+      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+    </modifySql>
+  </changeSet>
+  <changeSet author="jcr-index" id="1.0.0-3">
+    <createTable tableName="JCR_INDEXING_QUEUE_NODES">
+      <column name="JCR_INDEXING_QUEUE_NODE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_JCR_INDEXING_QUEUE_NODE_ID"/>
+      </column>
+      <column name="INDEXING_QUEUE_ID" type="BIGINT">
+        <constraints foreignKeyName="FK_JCR_INDEXING_QUEUE" references="JCR_INDEXING_QUEUE(INDEXING_QUEUE_ID)" nullable="false" deleteCascade="true" />
+      </column>
+      <column name="NODE_NAME" type="NVARCHAR(50)">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+    <modifySql dbms="mysql">
+      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+    </modifySql>
+  </changeSet>
+</databaseChangeLog>

--- a/exo.jcr.ext.services/src/test/java/org/exoplatform/services/jcr/ext/index/persistent/JCRIndexingServiceTest.java
+++ b/exo.jcr.ext.services/src/test/java/org/exoplatform/services/jcr/ext/index/persistent/JCRIndexingServiceTest.java
@@ -1,0 +1,113 @@
+package org.exoplatform.services.jcr.ext.index.persistent;
+
+import javax.jcr.Node;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.services.jcr.ext.BaseStandaloneTest;
+import org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingQueueDAOImpl;
+import org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingServiceImpl;
+
+public class JCRIndexingServiceTest extends BaseStandaloneTest {
+
+  private JCRIndexingServiceImpl  jcrIndexingService;
+
+  private JCRIndexingQueueDAOImpl indexingQueueDAO;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    indexingQueueDAO = ExoContainerContext.getService(JCRIndexingQueueDAOImpl.class);
+    jcrIndexingService = ExoContainerContext.getService(JCRIndexingServiceImpl.class);
+
+    RequestLifeCycle.begin(container);
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    RequestLifeCycle.end();
+  }
+
+  public void testCreateIndexEntity() throws Exception { // NOSONAR
+    saveAndProcessQueue();
+
+    Long initialCount = indexingQueueDAO.count();
+    assertNotNull(initialCount);
+
+    Node testRoot = session.getRootNode().addNode("testCreateIndexEntity");
+    Node node = testRoot.addNode("exo:test");
+    node.setProperty("jcr:prop", "property and node");
+    saveAndProcessQueue();
+
+    Long count = indexingQueueDAO.count();
+    assertNotNull(count);
+    assertEquals(initialCount.longValue() + 2, count.longValue());
+
+    jcrIndexingService.persistLastOperationId();
+    String lastExecutedOperation = jcrIndexingService.getLastExecutedOperation();
+    assertTrue(lastExecutedOperation.contains(";ClusterNodeName"));
+    lastExecutedOperation = lastExecutedOperation.replaceAll(";ClusterNodeName", "");
+    assertTrue(Long.parseLong(lastExecutedOperation) > count);
+  }
+
+  public void testUpdateIndexEntity() throws Exception { // NOSONAR
+    Node testRoot = session.getRootNode().addNode("testUpdateIndexEntity");
+    Node node = testRoot.addNode("exo:test");
+    node.setProperty("jcr:prop", "property and node");
+    saveAndProcessQueue();
+
+    Long initialCount = getQueueCount();
+    assertNotNull(initialCount);
+
+    node.setProperty("jcr:prop", "property and node 2");
+    saveAndProcessQueue();
+
+    Long count = indexingQueueDAO.count();
+    assertNotNull(count);
+    assertEquals(initialCount.longValue() + 2, count.longValue());
+
+    jcrIndexingService.persistLastOperationId();
+    String lastExecutedOperation = jcrIndexingService.getLastExecutedOperation();
+    assertTrue(lastExecutedOperation.contains(";ClusterNodeName"));
+    lastExecutedOperation = lastExecutedOperation.replaceAll(";ClusterNodeName", "");
+    assertTrue(Long.parseLong(lastExecutedOperation) > count);
+  }
+
+  public void testRemoveIndexEntity() throws Exception { // NOSONAR
+    Node testRoot = session.getRootNode().addNode("testRemoveIndexEntity");
+    Node node = testRoot.addNode("exo:test");
+    node.setProperty("jcr:prop", "property and node");
+    saveAndProcessQueue();
+
+    Long initialCount = getQueueCount();
+    assertNotNull(initialCount);
+
+    node.remove();
+    saveAndProcessQueue();
+
+    Long count = getQueueCount();
+    assertNotNull(count);
+    // "1" (One) indexation operations representing the 'NODE_ADD' operation
+    // will be removed from queue and then "1" (One) new unindex operation will
+    // be added requesting to unindex the node
+    assertEquals(initialCount.longValue() - 1 + 1, count.longValue());
+
+    jcrIndexingService.persistLastOperationId();
+    String lastExecutedOperation = jcrIndexingService.getLastExecutedOperation();
+    assertTrue(lastExecutedOperation.contains(";ClusterNodeName"));
+    lastExecutedOperation = lastExecutedOperation.replaceAll(";ClusterNodeName", "");
+    assertTrue(Long.parseLong(lastExecutedOperation) > count);
+  }
+
+  private long getQueueCount() {
+    return indexingQueueDAO.count();
+  }
+
+  private void saveAndProcessQueue() throws Exception { // NOSONAR
+    session.save();
+    jcrIndexingService.persistQueueOperations();
+  }
+
+}

--- a/exo.jcr.ext.services/src/test/resources/conf/standalone/test-configuration.xml
+++ b/exo.jcr.ext.services/src/test/resources/conf/standalone/test-configuration.xml
@@ -19,23 +19,14 @@
       <properties-param>
         <name>properties</name>
         <description>Log4J properties</description>
-        <property name="log4j.rootLogger" value="INFO, stdout, file"/>
+        <property name="log4j.rootLogger" value="INFO, stdout"/>
         
         <property name="log4j.appender.stdout" value="org.apache.log4j.ConsoleAppender"/>
         <property name="log4j.appender.stdout.threshold" value="INFO"/>
         
         <property name="log4j.appender.stdout.layout" value="org.apache.log4j.PatternLayout"/>
         <property name="log4j.appender.stdout.layout.ConversionPattern" value="%d{dd.MM.yyyy HH:mm:ss} *%-5p* [%t] %c{1}: %m (%F, line %L) %n"/>
-        
-        <property name="log4j.appender.file" value="org.apache.log4j.FileAppender"/>
-        <property name="log4j.appender.file.File" value="target/jcr.log"/>
-        
-        <property name="log4j.appender.file.layout" value="org.apache.log4j.PatternLayout"/>
-        <property name="log4j.appender.file.layout.ConversionPattern" value="%d{dd.MM.yyyy HH:mm:ss} *%-5p* [%t] %c{1}: %m (%F, line %L) %n"/>
-        
-        <!-- property name="log4j.category.ext.BackupScheduler" value="DEBUG"/>
-        <property name="log4j.category.ext.BackupManagerImpl" value="DEBUG"/ -->
-        
+        <property name="log4j.logger.org.exoplatform.commons.persistence.impl" value="DEBUG" />
       </properties-param>
     </init-params>
   </component>
@@ -168,6 +159,21 @@
         <name>locations</name>
         <property name="db1" value="ws2"/>
       </properties-param>
+    </init-params>
+  </component>
+
+  <component>
+    <key>org.exoplatform.commons.api.persistence.DataInitializer</key>
+    <type>org.exoplatform.commons.persistence.impl.LiquibaseDataInitializer</type>
+    <init-params>
+      <value-param>
+        <name>liquibase.datasource</name>
+        <value>${exo.jpa.datasource.name:java:/comp/env/exo-jpa_portal}</value>
+      </value-param>
+      <value-param>
+        <name>liquibase.contexts</name>
+        <value>${exo.liquibase.contexts:production}</value>
+      </value-param>
     </init-params>
   </component>
 
@@ -467,7 +473,55 @@
       </value-param>
     </init-params>
   </component>
-  
+
+  <component>
+    <key>org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingQueueDAO</key>
+    <type>org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingQueueDAOImpl</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.services.jcr.ext.index.persistent.api.JCRIndexingService</key>
+    <type>org.exoplatform.services.jcr.ext.index.persistent.impl.JCRIndexingServiceImpl</type>
+    <init-params>
+      <value-param>
+        <name>cluster.node.name</name>
+        <description>Cluster node name</description>
+        <value>${exo.cluster.node.name:ClusterNodeName}</value>
+      </value-param>
+      <value-param>
+        <name>batch.number</name>
+        <description>Batching count when processing elements from queue
+        after retrieving indexes from coordinator/master</description>
+        <value>${exo.jcr.indexing.persistent.queue.batch.number:100}</value>
+      </value-param>
+      <value-param>
+        <name>queue.periodicity.seconds</name>
+        <description>Periodicity of asunchronous queue processing
+        to index nodes that has changes made by other Cluster nodes</description>
+        <value>${exo.jcr.indexing.persistent.queue.periodicity.seconds:1}</value>
+      </value-param>
+    </init-params>
+  </component>
+
+  <component>
+    <key>org.exoplatform.services.rpc.RPCService</key>
+    <type>org.exoplatform.services.rpc.jgv3.RPCServiceImpl</type>
+    <init-params>
+      <value-param>
+        <name>jgroups-configuration</name>
+        <value>jar:/conf/jcr/jgroups/jgroups-jcr-tcp.xml</value>
+      </value-param>
+      <value-param>
+        <name>jgroups-cluster-name</name>
+        <value>RPCService-Cluster</value>
+      </value-param>
+      <value-param>
+        <name>jgroups-default-timeout</name>
+        <value>0</value>
+      </value-param>
+    </init-params>
+  </component>
+
   <!-- org service initializer, copied from ECM portal.war -->
   <external-component-plugins>
     <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
@@ -732,6 +786,38 @@
      </component-plugin>
   </external-component-plugins>
 
+    <!-- Bind datasource -->
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.naming.InitialContextInitializer</target-component>
+    <component-plugin>
+      <name>bind.datasource</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.services.naming.BindReferencePlugin</type>
+      <init-params>
+        <value-param>
+          <name>bind-name</name>
+          <value>java:/comp/env/exo-jpa_portal</value>
+        </value-param>
+        <value-param>
+          <name>class-name</name>
+          <value>javax.sql.DataSource</value>
+        </value-param>
+        <value-param>
+          <name>factory</name>
+          <value>org.apache.commons.dbcp.BasicDataSourceFactory</value>
+        </value-param>
+        <properties-param>
+          <name>ref-addresses</name>
+          <description>ref-addresses</description>
+          <property name="driverClassName" value="org.hsqldb.jdbcDriver" />
+          <property name="url" value="jdbc:hsqldb:mem:db1" />
+          <property name="username" value="sa" />
+          <property name="password" value="" />
+        </properties-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
   <external-component-plugins>
     <target-component>org.exoplatform.services.naming.InitialContextInitializer</target-component>
     <component-plugin>
@@ -789,5 +875,21 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
-  
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>CommonsChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of commons</description>
+          <value>db/changelog/jcr-index.db.changelog-1.0.0.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/exo.jcr.ext.services/src/test/resources/conf/standalone/test-jcr-ext-config.xml
+++ b/exo.jcr.ext.services/src/test/resources/conf/standalone/test-jcr-ext-config.xml
@@ -16,15 +16,17 @@
               <property name="swap-directory" value="target/temp/db1/swap/ws"/>
             </properties>
           </container>
-            <cache enabled="true"
-              class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
-              <properties>
-                 <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
-              </properties>
-            </cache>
+          <cache enabled="true" class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
+            <properties>
+              <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
+            </properties>
+          </cache>
           <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
             <properties>
               <property name="index-dir" value="target/temp/db1/index/ws" />
+              <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+              <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+              <property name="max-volatile-time" value="60" />
             </properties>
           </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
@@ -59,11 +61,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws1" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws1" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -96,11 +101,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws2" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws2" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -133,11 +141,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws3" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws3" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -170,11 +181,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws4" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws4" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -207,11 +221,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws5" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws5" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -244,11 +261,14 @@
                  <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
               </properties>
             </cache>
-          <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
-            <properties>
-              <property name="index-dir" value="target/temp/db1/index/ws6" />
-            </properties>
-          </query-handler>
+            <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
+              <properties>
+                <property name="index-dir" value="target/temp/db1/index/ws6" />
+                <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+                <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+                <property name="max-volatile-time" value="60" />
+              </properties>
+            </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
              <properties>
                 <property name="time-out" value="15m" />
@@ -283,15 +303,18 @@
               <property name="swap-directory" value="target/temp/db2/swap/ws"/>
             </properties>
           </container>
-            <cache enabled="true"
-              class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
-              <properties>
-                 <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
-              </properties>
-            </cache>
+          <cache enabled="true"
+            class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
+            <properties>
+               <property name="infinispan-configuration" value="conf/standalone/test-infinispan-config.xml" />
+            </properties>
+          </cache>
           <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
             <properties>
               <property name="index-dir" value="target/temp/db2/index/ws" />
+              <property name="changesfilter-class" value="org.exoplatform.services.jcr.ext.index.persistent.filter.PersistentIndexChangesFilter" />
+              <property name="infinispan-cluster-name" value="jcrindexer${container.name.suffix}" />
+              <property name="max-volatile-time" value="60" />
             </properties>
           </query-handler>
           <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">

--- a/exo.jcr.ext.services/src/test/resources/test.policy
+++ b/exo.jcr.ext.services/src/test/resources/test.policy
@@ -7,6 +7,10 @@ grant codeBase "@MAIN_CLASSES@-"{
 };
 
 grant codeBase "@TEST_CLASSES@-"{
+   permission java.security.AllPermission;
+};
+
+grant codeBase "@TEST_CLASSES@org/exoplatform/services/jcr/ext/audit/-"{
    permission java.lang.RuntimePermission "createSystemSession";
    permission java.lang.RuntimePermission "manageRepository";
    permission java.lang.RuntimePermission "invokeInternalAPI";

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.exoplatform</groupId>
-    <artifactId>foundation-parent</artifactId>
-    <version>20</version>
-    <relativePath />
+    <artifactId>addons-parent-pom</artifactId>
+    <groupId>org.exoplatform.addons</groupId>
+    <version>12</version>
+    <relativePath/>
   </parent>
 
   <groupId>org.exoplatform.jcr</groupId>
@@ -49,6 +49,8 @@
     <org.exoplatform.social.version>6.0.x-SNAPSHOT</org.exoplatform.social.version>
     <org.antlr.version>3.5</org.antlr.version>
     <contiperf.version>2.2.0</contiperf.version>
+    <!-- Backward compatibility -->
+    <junit.version>4.10</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -143,6 +145,12 @@
          <artifactId>contiperf</artifactId>
          <version>${contiperf.version}</version>
          <scope>test</scope>
+      </dependency>
+      <!-- Kept for Backward compatibility -->
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>${junit.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Backport of https://github.com/exodev/jcr/pull/65

Please read more about this strategy in the following document:
https://docs.google.com/document/d/1Q-pcqnRV6R8i2RSD-93i5s5Qc3bS4KkdfE8f1c3XuPs/edit?ts=597f342e#heading=h.m63huo9v8iz8

* Switch default Cluster configuration to use TCP instead of UDP

* Copy implementation of Persistent changelog made in PR https://github.com/exodev/commons/pull/133

* Enhance code readability

* Move Persistent changelog API to an appropriate package

* Add Unit Tests and enhance code with Java 8

* Use old version of JUnit for backward compatibility

* Inherit version of maven plugin instead of declaring it explicitely

* Include Test file

* Store file content in Test before doing assertions

* Enhance last operation identifier storage and fix DB sequence definition

* Avoid executing Index recovery on startup

* Avoid useless blocking indexing synchronization with persistent index strategy

* Enhance Fault tolerance for JCR reading operations when reindexing
When reindexing JCR content, we may encounter sometimes some inconsistent Data. Knowing that the JCR will not be correctly accessible at all when not having a minimal index information, this improvement ensures to not stop indexation even when encountering some inconsistent data and still continue indexing other consistent data.
In addition, in clustering, the Suspend/resume of containers when stopping servers aren't mandatory since we will have a unique data storage and no multiple databases (Deprecated and not used at all). Thus it has been disabled by default to allow :
1/ Restart servers without affecting state (Online/Offline) status of other nodes in the cluster
2/ Starting a fresh node
3/ Reindexing on one single node

* Compress all index folder before sending it back to cluster member

* Retrieve Last operation ID File from coordinator before retrieving indexes

* Optimize code by deleting useless parts