### PR TITLE
TASK-39447 FIX Creating JCR Index Queue on PostgreSQL

### DIFF
--- a/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
+++ b/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
@@ -53,4 +53,9 @@
       <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
     </modifySql>
   </changeSet>
+  <changeSet author="jcr-index" id="1.0.0-4" dbms="oracle,postgresql">
+    <dropPrimaryKey tableName="JCR_INDEXING_QUEUE_NODES" constraintName="PK_JCR_INDEXING_QUEUE_NODE_ID" />
+    <dropColumn tableName="JCR_INDEXING_QUEUE_NODES" columnName="JCR_INDEXING_QUEUE_NODE_ID" />
+    <addPrimaryKey tableName="JCR_INDEXING_QUEUE_NODES" columnNames="INDEXING_QUEUE_ID, NODE_NAME" constraintName="PK_JCR_INDEXING_QUEUE_NODE_COMPOSITE_ID" />
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The autoincrement liquibase option on Primary keys can't be applied on PostgreSQL, thus we have to create sequences on database.
Knowing that sequence can't be generated on a '@CollectionTable', a composite primary key has been added to table 'JCR_INDEXING_QUEUE_NODES'