### PR TITLE
TASK-38913 Avoid throwing an exception when cleaning SessionProvider twice

### DIFF
--- a/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/common/SessionProvider.java
+++ b/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/common/SessionProvider.java
@@ -23,6 +23,8 @@ import org.exoplatform.services.jcr.access.DynamicIdentity;
 import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.core.SessionLifecycleListener;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
@@ -50,6 +52,8 @@ import javax.jcr.Session;
 
 public class SessionProvider implements SessionLifecycleListener
 {
+
+   protected static final Log LOG = ExoLogger.getLogger("exo.jcr.component.ext.SessionProvider");
 
    /**
     * Constant for handlers.
@@ -219,9 +223,13 @@ public class SessionProvider implements SessionLifecycleListener
    public synchronized void close()
    {
 
-      if (closed)
-      {
-         throw new IllegalStateException("Session provider already closed");
+      if (closed) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace(new IllegalStateException("Session is already closed"));
+        } else {
+          LOG.debug("Session is already closed");
+        }
+        return;
       }
 
       closed = true;


### PR DESCRIPTION
Returning a boolean is more adequate here since it shouldn't fail a whole user query when trying to just make a cleanup of resources. Throwing an exception should be made to prevent incoherent logic to be made, to be used also to ensure data consistency... But when cleaning up, just returning a boolean is sufficient to let upper layer know if the SessionProvider was already closed or not.

In addition in this PR, useless and long running Unit Test for deprecated Backup/Restore procedure are evicted.