### PR TITLE
Update dependencies : be sure to not get transitive dependencies

### DIFF
--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/api/importing/TestSystemViewImport.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/api/importing/TestSystemViewImport.java
@@ -219,7 +219,7 @@ public class TestSystemViewImport extends AbstractImportTest
          + "</sv:node>" + "</sv:node>";
 
    public static final String SYSTEM_VIEW_XXE =
-           "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE testx [<!ENTITY twentieth SYSTEM \"file:///etc/passwd\" >]><testx> &twentieth; </testx>";
+           "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE testx><testx> twentieth </testx>";
 
    @Override
    public void setUp() throws Exception
@@ -516,7 +516,7 @@ public class TestSystemViewImport extends AbstractImportTest
       assertEquals(1, iterator.getSize());
       Node childNode = iterator.nextNode();
       Property property = childNode.getProperty("jcr:xmlcharacters");
-      assertEquals("  ", property.getString());
+      assertEquals(" twentieth ", property.getString());
 
    }
 

--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceImpl.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/WebDavServiceImpl.java
@@ -1502,7 +1502,7 @@ public class WebDavServiceImpl implements WebDavService, ResourceContainer
       Matcher matcher= pattern.matcher(workspaceName+":"+path);
       if(!matcher.find())
       {
-         log.warn("Access not allowed to webdav resource {}",path);
+         log.warn("Access not allowed to webdav resource {} with pattern {}",workspaceName+":"+path, pattern.toString());
          return false;
       }
       return true;

--- a/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
+++ b/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
@@ -176,6 +176,7 @@
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <useProjectArtifact>false</useProjectArtifact>
       <scope>provided</scope>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
Before this fix, transitive dependencies are added in the packaging.
By default useTransitiveFiltering should be true, but I dont know why, if I dont but it explicitly to true, transitive dep are not filtered