### PR TITLE
TASK-26265 centralise third party libraries versions in maven-depmgt-pom

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -31,7 +31,7 @@
    <name>eXo PLF:: JCR :: Component :: Core Service</name>
    <description>Implementation of Core Service of Exoplatform SAS 'eXo Core' project.</description>
    <properties>
-      <exo.test.coverage.ratio>0.52</exo.test.coverage.ratio>
+      <exo.test.coverage.ratio>0.51</exo.test.coverage.ratio>
       <jcr.test.configuration.file>/conf/standalone/test-configuration-ijdbc-ispn.xml</jcr.test.configuration.file>
       <cache.enabled>true</cache.enabled>
       <use.sequence>auto</use.sequence>
@@ -47,6 +47,7 @@
       <test.exclude>**/foo/foo/**</test.exclude>
       <debug.opts />
       <argLine>${env.MAVEN_OPTS} -Djava.net.preferIPv4Stack=true -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy ${debug.opts}</argLine>
+      <contiperf.version>2.4.3</contiperf.version>
    </properties>
    <dependencies>
       <dependency>
@@ -112,7 +113,7 @@
          <artifactId>jta</artifactId>
       </dependency>
       <dependency>
-         <groupId>concurrent</groupId>
+         <groupId>oswego-concurrent</groupId>
          <artifactId>concurrent</artifactId>
       </dependency>
       <dependency>
@@ -214,8 +215,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.databene</groupId>
+         <groupId>com.github.javatlacati</groupId>
          <artifactId>contiperf</artifactId>
+         <version>${contiperf.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/api/version/TestVersionableThreadSafety.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/api/version/TestVersionableThreadSafety.java
@@ -18,28 +18,22 @@
  */
 package org.exoplatform.services.jcr.api.version;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.databene.contiperf.PerfTest;
-import org.databene.contiperf.junit.ContiPerfRule;
-import org.exoplatform.services.jcr.core.ExtendedNode;
-import org.exoplatform.services.jcr.impl.Constants;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.jcr.ItemExistsException;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
+import javax.jcr.*;
+
+import org.junit.*;
+
+import com.github.javatlacati.contiperf.PerfTest;
+import com.github.javatlacati.contiperf.junit.ContiPerfRule;
+
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.impl.Constants;
 
 /**
  * @author <a href="mailto:nfilotto@exoplatform.com">Nicolas Filotto</a>

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestSimilarity.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestSimilarity.java
@@ -18,6 +18,8 @@ package org.exoplatform.services.jcr.impl.core.query;
 
 import org.exoplatform.services.jcr.api.core.query.AbstractIndexingTest;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Calendar;
 
 import javax.jcr.Node;

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorkspaceDataManager.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/dataflow/persistent/TestCacheableWorkspaceDataManager.java
@@ -16,55 +16,34 @@
  */
 package org.exoplatform.services.jcr.impl.dataflow.persistent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-import org.databene.contiperf.PerfTest;
-import org.databene.contiperf.junit.ContiPerfRule;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.*;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jcr.*;
+
+import org.junit.*;
+
+import com.github.javatlacati.contiperf.PerfTest;
+import com.github.javatlacati.contiperf.junit.ContiPerfRule;
+
 import org.exoplatform.services.jcr.JcrImplBaseTest;
 import org.exoplatform.services.jcr.config.WorkspaceEntry;
 import org.exoplatform.services.jcr.core.WorkspaceContainerFacade;
 import org.exoplatform.services.jcr.dataflow.ItemStateChangesLog;
-import org.exoplatform.services.jcr.dataflow.persistent.PersistedNodeData;
-import org.exoplatform.services.jcr.dataflow.persistent.PersistedPropertyData;
-import org.exoplatform.services.jcr.dataflow.persistent.WorkspaceStorageCache;
-import org.exoplatform.services.jcr.dataflow.persistent.WorkspaceStorageCacheListener;
-import org.exoplatform.services.jcr.datamodel.ItemData;
-import org.exoplatform.services.jcr.datamodel.ItemType;
-import org.exoplatform.services.jcr.datamodel.NodeData;
-import org.exoplatform.services.jcr.datamodel.PropertyData;
-import org.exoplatform.services.jcr.datamodel.QPath;
-import org.exoplatform.services.jcr.datamodel.QPathEntry;
-import org.exoplatform.services.jcr.datamodel.ValueData;
+import org.exoplatform.services.jcr.dataflow.persistent.*;
+import org.exoplatform.services.jcr.datamodel.*;
 import org.exoplatform.services.jcr.impl.Constants;
 import org.exoplatform.services.jcr.impl.core.PropertyImpl;
-import org.exoplatform.services.jcr.impl.core.itemfilters.ExactQPathEntryFilter;
-import org.exoplatform.services.jcr.impl.core.itemfilters.PatternQPathEntryFilter;
-import org.exoplatform.services.jcr.impl.core.itemfilters.QPathEntryFilter;
+import org.exoplatform.services.jcr.impl.core.itemfilters.*;
 import org.exoplatform.services.jcr.impl.storage.SystemDataContainerHolder;
 import org.exoplatform.services.jcr.impl.storage.WorkspaceDataContainerBase;
 import org.exoplatform.services.jcr.storage.WorkspaceDataContainer;
 import org.exoplatform.services.jcr.storage.WorkspaceStorageConnection;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.jcr.InvalidItemStateException;
-import javax.jcr.Node;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
 
 /**
  * Created by The eXo Platform SAS

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/utils/io/TestSwapFileThreadSafety.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/utils/io/TestSwapFileThreadSafety.java
@@ -21,19 +21,17 @@ package org.exoplatform.services.jcr.impl.utils.io;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.databene.contiperf.PerfTest;
-import org.databene.contiperf.junit.ContiPerfRule;
-import org.exoplatform.services.jcr.impl.util.io.SwapFile;
+import java.io.*;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.github.javatlacati.contiperf.PerfTest;
+import com.github.javatlacati.contiperf.junit.ContiPerfRule;
+
+import org.exoplatform.services.jcr.impl.util.io.SwapFile;
 
 /**
  * @author <a href="mailto:nfilotto@exoplatform.com">Nicolas Filotto</a>

--- a/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/MockHttpServletRequest.java
+++ b/exo.jcr.component.webdav/src/test/java/org/exoplatform/services/jcr/webdav/MockHttpServletRequest.java
@@ -29,19 +29,8 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.Part;
+import javax.servlet.*;
+import javax.servlet.http.*;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
@@ -396,6 +385,22 @@ public class MockHttpServletRequest implements HttpServletRequest
    {
       return null;
    }
+
+  @Override
+  public long getContentLengthLong() {
+    return getContentLength();
+  }
+
+  @Override
+  public String changeSessionId() {
+    return getRequestedSessionId();
+  }
+
+  @Override
+  public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+    // Nothing to do
+    return null;
+  }
 }
 
 class EnumerationImpl<T> implements Enumeration<T>
@@ -434,5 +439,20 @@ class MockServletInputStream extends ServletInputStream
    {
       return data.read();
    }
+
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public void setReadListener(ReadListener readListener) {
+    // Nothing to do
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,7 @@
   </scm>
 
   <properties>
-    <exo.product.name>exo-jcr</exo.product.name>
-    <exo.product.specification>1.16</exo.product.specification>
     <org.exoplatform.social.version>6.2.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.antlr.version>3.5</org.antlr.version>
-    <contiperf.version>2.2.0</contiperf.version>
-    <!-- Backward compatibility -->
-    <junit.version>4.10</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -128,29 +122,6 @@
         <artifactId>jcr-packaging</artifactId>
         <type>zip</type>
         <version>${project.version}</version>
-      </dependency>
-      <!-- Declare third party artifacts -->
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr-runtime</artifactId>
-        <version>${org.antlr.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>gunit</artifactId>
-        <version>${org.antlr.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.databene</groupId>
-         <artifactId>contiperf</artifactId>
-         <version>${contiperf.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <!-- Kept for Backward compatibility -->
-      <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <version>${junit.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR will:
* upgrade Servlet API to Tomcat 8.5+ version
* reuse centralized libraries coming from maven-depmgt-pom project