### PR TITLE
TASK-44923: Make sure to be able to create news article in Arabic language.

### DIFF
--- a/exo.jcr.ext.services/src/main/resources/conf/configuration.xml
+++ b/exo.jcr.ext.services/src/main/resources/conf/configuration.xml
@@ -50,7 +50,7 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins profiles="cluster">
+  <external-component-plugins>
     <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
     <component-plugin>
       <name>CommonsChangeLogsPlugin</name>

--- a/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
+++ b/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
@@ -58,4 +58,9 @@
     <dropColumn tableName="JCR_INDEXING_QUEUE_NODES" columnName="JCR_INDEXING_QUEUE_NODE_ID" />
     <addPrimaryKey tableName="JCR_INDEXING_QUEUE_NODES" columnNames="INDEXING_QUEUE_ID, NODE_NAME" constraintName="PK_JCR_INDEXING_QUEUE_NODE_COMPOSITE_ID" />
   </changeSet>
+  <changeSet author="jcr-index" id="1.0.0-5" dbms="mysql">
+    <sql>
+      ALTER TABLE JCR_SITEM MODIFY COLUMN NAME varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Since we moved to Mysql server 8.0, the newly deployed platforms encounter a problem in news article written in Arabic.
The fired exception is: "java.sql.SQLException: Illegal mix of collations (latin1_general_cs,IMPLICIT) and (utf8mb4_0900_ai_ci,COERCIBLE) for operation '='".
By digging in this issue i found out that the column JCR_SITEM.NAME has a collation "latin1_general_cs" defined explicitly since table creation.
The cause of this sql exception is that the query executed: "SELECT 
    *
FROM
    exo.JCR_SITEM
WHERE
    exo.JCR_SITEM.CONTAINER_NAME = 'collaboration'
        AND exo.JCR_SITEM.PARENT_ID = 'collaborationxxxxxxxxxx'
        AND exo.JCR_SITEM.NAME = 'arabic text'
        AND exo.JCR_SITEM.I_INDEX = 1
ORDER BY exo.JCR_SITEM.I_CLASS;"
has a mix of collations since the default collation of Mysql 8.0 is "utf8mb4_0900_ai_ci" and so we have the collation of the column JCR_SITEM.NAME thats differs from the collation of the table itself and the rest of the fields which are member of the sql query.
**Fix:** as a fix i updated the column JCR_SITEM.NAME collation to the Mysql 8.0's default collation.