### PR TITLE
TASK-49405 Add More information about JCR node identifier when an unc…

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/SessionDataManager.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/SessionDataManager.java
@@ -678,6 +678,12 @@ public class SessionDataManager implements ItemDataConsumer
       {
          return item = readItem(getItemData(identifier), null, pool, apiRead);
       }
+      catch (RepositoryException e) {
+        throw e;
+      }
+      catch (Exception e) {
+        throw new RepositoryException("An error occurred while reading item data with identifier: " + identifier, e);
+      }
       finally
       {
          if (LOG.isDebugEnabled())


### PR DESCRIPTION
…hecked exception happens (#260)

Prior to this change, the unchecked exceptions coming from reading a JCR node doesn't give information about node identifier causing the problem. This modification will add this information by encapsulating all other exceptions different from RepositoryException.

(cherry picked from commit 7b6a1f5ceaec9876cecf6da530b321ebbe84c7c9)