### PR TITLE
TASK-53062 Upgrade to Hibernate 5.6

### DIFF
--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/entity/JCRIndexQueueEntity.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/index/persistent/entity/JCRIndexQueueEntity.java
@@ -55,7 +55,7 @@ import org.exoplatform.services.jcr.ext.index.persistent.JCRIndexingOperationTyp
 public class JCRIndexQueueEntity {
   @Id
   @Column(name = "INDEXING_QUEUE_ID")
-  @SequenceGenerator(name = "SEQ_JCR_INDEXING_QUEUE", sequenceName = "SEQ_JCR_INDEXING_QUEUE")
+  @SequenceGenerator(name = "SEQ_JCR_INDEXING_QUEUE", sequenceName = "SEQ_JCR_INDEXING_QUEUE", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_JCR_INDEXING_QUEUE")
   private long                     id;
 

--- a/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
+++ b/exo.jcr.ext.services/src/main/resources/db/changelog/jcr-index.db.changelog-1.0.0.xml
@@ -58,4 +58,9 @@
     <dropColumn tableName="JCR_INDEXING_QUEUE_NODES" columnName="JCR_INDEXING_QUEUE_NODE_ID" />
     <addPrimaryKey tableName="JCR_INDEXING_QUEUE_NODES" columnNames="INDEXING_QUEUE_ID, NODE_NAME" constraintName="PK_JCR_INDEXING_QUEUE_NODE_COMPOSITE_ID" />
   </changeSet>
+
+  <changeSet author="jcr-index" id="1.0.0-5" dbms="hsqldb">
+    <createSequence sequenceName="SEQ_JCR_INDEXING_QUEUE" startValue="1"/>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
    To make the upgrade to Hibernate 5.6, this commit will generate Sequences for hsqldb which wasn't mandatory in previous versions of Hibernate and ensure to manage Sequence allocation size correctly switch Liquibase Configured incrementation (Default = 1)