### PR TITLE
Task-55630: Element couldn't be deleted (send to trash)

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>jcr-parent</artifactId>
-      <version>6.4.x-SNAPSHOT</version>
+      <version>6.4.x-maintenance-SNAPSHOT</version>
    </parent>
    <artifactId>exo.jcr.component.core</artifactId>
    <name>eXo PLF:: JCR :: Component :: Core Service</name>

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/WorkspaceImpl.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/WorkspaceImpl.java
@@ -462,16 +462,22 @@ public class WorkspaceImpl implements ExtendedWorkspace
             (NodeData)srcParentNode.getData(), nodeTypeManager, session.getTransientNodesManager(), true,
             triggerEventsForDescendants, session.maxDescendantNodesAllowed);
 
-      srcNode.getData().accept(initializer);
-      PlainChangesLog changes = new PlainChangesLogImpl(initializer.getAllStates(), session);
+      try {
+         srcNode.getData().accept(initializer);
+      } catch (Exception e) {
+         LOG.warn(e.getMessage());
+      }
+      finally {
+         PlainChangesLog changes = new PlainChangesLogImpl(initializer.getAllStates(), session);
 
-      // reload items pool
-      session.getTransientNodesManager().reloadItems(initializer);
+         // reload items pool
+         session.getTransientNodesManager().reloadItems(initializer);
 
-      session.getActionHandler().postMove(srcNode, (NodeImpl) session.getTransientNodesManager().
-         readItem(initializer.getItemMoveState().getData(), destParentNode.nodeData(), false, false));
-      // persist the changes
-      session.getTransientNodesManager().getTransactManager().save(changes);
+         session.getActionHandler().postMove(srcNode, (NodeImpl) session.getTransientNodesManager().
+                 readItem(initializer.getItemMoveState().getData(), destParentNode.nodeData(), false, false));
+         // persist the changes
+         session.getTransientNodesManager().getTransactManager().save(changes);
+      }
    }
 
    /**

--- a/exo.jcr.component.ext/pom.xml
+++ b/exo.jcr.component.ext/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.component.ext</artifactId>
   <name>eXo PLF:: JCR :: Component :: Extension Service</name>

--- a/exo.jcr.component.ftp/pom.xml
+++ b/exo.jcr.component.ftp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.component.ftp</artifactId>
   <name>eXo PLF:: JCR :: Component :: FTP Service</name>

--- a/exo.jcr.component.statistics/pom.xml
+++ b/exo.jcr.component.statistics/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.component.statistics</artifactId>
   <name>eXo PLF:: JCR :: Component :: Statistics Provider</name>

--- a/exo.jcr.component.webdav/pom.xml
+++ b/exo.jcr.component.webdav/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.component.webdav</artifactId>
   <name>eXo PLF:: JCR :: Component :: Webdav Service</name>

--- a/exo.jcr.connectors.jca/pom.xml
+++ b/exo.jcr.connectors.jca/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.connectors.jca</artifactId>
   <packaging>rar</packaging>

--- a/exo.jcr.ext.services/pom.xml
+++ b/exo.jcr.ext.services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/exo.jcr.framework.command/pom.xml
+++ b/exo.jcr.framework.command/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>jcr-parent</artifactId>
-      <version>6.4.x-SNAPSHOT</version>
+      <version>6.4.x-maintenance-SNAPSHOT</version>
    </parent>
    <artifactId>exo.jcr.framework.command</artifactId>
    <name>eXo PLF:: JCR :: Framework :: Command</name>

--- a/exo.jcr.framework.ftpclient/pom.xml
+++ b/exo.jcr.framework.ftpclient/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.framework.ftpclient</artifactId>
   <name>eXo PLF:: JCR :: Framework :: FTP Client</name>

--- a/exo.jcr.framework.web/pom.xml
+++ b/exo.jcr.framework.web/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.jcr.framework.web</artifactId>
   <name>eXo PLF:: JCR :: Framework :: Web</name>

--- a/jcr-packaging/pom.xml
+++ b/jcr-packaging/pom.xml
@@ -24,7 +24,7 @@
  <parent>
     <groupId>org.exoplatform.jcr</groupId>
     <artifactId>jcr-parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
  </parent>
   <artifactId>jcr-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.exoplatform.jcr</groupId>
   <artifactId>jcr-parent</artifactId>
-  <version>6.4.x-SNAPSHOT</version>
+  <version>6.4.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: JCR</name>
   <description>Exoplatform SAS 'eXo JCR'(JSR-170 implementation) project.</description>
@@ -44,7 +44,7 @@
   </scm>
 
   <properties>
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.social.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
     
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>


### PR DESCRIPTION
Problem: sometimes, a message error appears when trying to delete a WebContent from a specific site or trash.
Fix: this error owing to getting empty properties of nodeData in phase move to trash or delete from trash by calling the function visitChildProperties (NodeData node).In this fix, I catch this exception and continue the process of moving or deleting permanently from the trash.