### PR TITLE
Update tika library to fix security vulnerabilities - EXO-59397

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -220,9 +220,13 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <scope>test</scope>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.spec.javax.rmi</groupId>
+         <artifactId>jboss-rmi-api_1.0_spec</artifactId>
       </dependency>
    </dependencies>
   <!-- ======================================================================= -->


### PR DESCRIPTION
Before this fix, Snyk show vulnerabilities in tikar version 1.25 This commit update the tika version from 1.25 to 1.28.4. In addition, it will update the tika depencendy junrar from 7.4.0 to 7.5.2 As tika is no more dependent of jboss-rmi-api_1.0_spec, we need to readd it manually in jcr