### PR TITLE
fix: Images aren't displayed  in shared news content - EXO-61176

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/SessionDataManager.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/SessionDataManager.java
@@ -621,7 +621,7 @@ public class SessionDataManager implements ItemDataConsumer
 
          if (apiRead)
          {
-            if (!item.hasPermission(PermissionType.READ))
+            if (!item.hasPermission(PermissionType.READ)  && (!item.getPath().contains("news") && !item.getPath().contains("images")) )
             {
                throw new AccessDeniedException("Access denied " + itemData.getQPath().getAsString() + " for "
                   + session.getUserID());


### PR DESCRIPTION
before this change, images are not accessible from a shared news of a space I'm not a member of, since the user doesn't have the right to see them
after this change, the images are displayed successfully after avoiding to check the permission for the news images