### PR TITLE
fix: Error when starting Server, class javax.ws.core.Link not found - EXO-62860 - Meeds-io/MIPs#42

### DIFF
--- a/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
+++ b/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
@@ -37,6 +37,7 @@
         <exclude>org.exoplatform.ws:*:*</exclude>
         <exclude>org.exoplatform.kernel:*:*</exclude>
         <exclude>org.exoplatform.core:*:*</exclude>
+        <exclude>org.apache.cxf:*</exclude>
         <!-- No Apache Tomcat artifacts have to be added in the packaging -->
         <exclude>org.apache.tomcat:*</exclude>
         <!-- Ant and related aren't really useful for us at runtime -->


### PR DESCRIPTION
Before this fix, and after the merge of MIP-42, the server does not start because the class javax.ws.core.Link was not found It is due to new jars added in jcr via dependencies on Tika which bring dependencies on org.apache.cxf which do not need. This commit exclude the problematic wars.