### PR TITLE
fix: add missing PDF dependency - EXO-63719 (#297)

### DIFF
--- a/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
+++ b/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
@@ -144,7 +144,6 @@
         <exclude>*:jboss-marshalling-osgi:jar</exclude>
         <exclude>*:jbossjta:jar</exclude>
         <exclude>*:jcl-over-slf4j:jar</exclude>
-        <exclude>*:jempbox:jar</exclude>
         <exclude>*:jgroups:jar</exclude>
         <exclude>*:jhighlight:jar</exclude>
         <exclude>*:jibx-run:jar</exclude>


### PR DESCRIPTION
Uploading PDF files throws an exception because of a missing dependency jempbox This dependency was filtered from the packaging and we need to remove the filtering after the dependency cleanup fixes.