### PR TITLE
fix: remove unused transitive dependency cxf client - EXO-64344

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -158,6 +158,10 @@
                <artifactId>tika-core</artifactId>
             </exclusion>
             <exclusion>
+               <groupId>org.apache.cxf</groupId>
+               <artifactId>cxf-rt-rs-client</artifactId>
+            </exclusion>
+            <exclusion>
                <groupId>org.apache.geronimo.specs</groupId>
                <artifactId>geronimo-stax-api_1.0_spec</artifactId>
             </exclusion>

--- a/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/ActivityTypeUtils.java
+++ b/exo.jcr.ext.services/src/main/java/org/exoplatform/services/jcr/ext/ActivityTypeUtils.java
@@ -55,7 +55,7 @@ public class ActivityTypeUtils {
       if (!ownerNode.isCheckedOut()) {
         verNode = checkout(ownerNode);
       }
-      if (ownerNode.isNodeType(EXO_ACTIVITY_INFO) == false && ownerNode.canAddMixin(EXO_ACTIVITY_INFO)) {
+      if (!ownerNode.isNodeType(EXO_ACTIVITY_INFO) && ownerNode.canAddMixin(EXO_ACTIVITY_INFO)) {
         ownerNode.addMixin(EXO_ACTIVITY_INFO);
       }
       ownerNode.setProperty(EXO_ACTIVITY_ID, activityId);


### PR DESCRIPTION
This will remove an unused transitive dependency **cxf-rt-rs-client** that causes issues in Unit tests