### PR TITLE
fix: Move back Log4J API dependency to Meeds - MEED-3174 - Meeds-io/meeds#1540

### DIFF
--- a/exo.jcr.component.core/pom.xml
+++ b/exo.jcr.component.core/pom.xml
@@ -141,10 +141,6 @@
          <artifactId>log4j-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.apache.logging.log4j</groupId>
-         <artifactId>log4j-to-slf4j</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.apache.tika</groupId>
          <artifactId>tika-core</artifactId>
       </dependency>

--- a/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
+++ b/jcr-packaging/src/main/assemblies/jcr-addon-package.xml
@@ -47,6 +47,7 @@
         <exclude>commons-logging:*</exclude>
         <!-- log4j is forbidden and must be replaced by org.slf4j:log4j-over-slf4j -->
         <exclude>log4j:*</exclude>
+        <exclude>org.apache.logging.log4j:*</exclude>
         <!-- We use jcl-over-slf4j, thus this one is forbidden to avoid infinite loops -->
         <exclude>org.slf4j:slf4j-jcl:*</exclude>
         <!-- We use log4j-over-slf4j, thus this one is forbidden to avoid infinite loops -->


### PR DESCRIPTION
Prior to this change, the Log4J API was used only by JCR dependencies. This change will move the Log4J API dependency to gamification since it's requested by apache POI used to export achievements in Excel format.

( Resolves Meeds-io/meeds#1540 )