### PR TITLE
fix: Wrong modifier avatar displayed in file details - EXO-69919

### DIFF
--- a/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/action/ModifyNodeAction.java
+++ b/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/action/ModifyNodeAction.java
@@ -23,6 +23,7 @@ import javax.jcr.Property;
 
 import org.apache.commons.chain.Context;
 import org.exoplatform.services.command.action.Action;
+import org.exoplatform.services.jcr.impl.core.PropertyImpl;
 import org.exoplatform.services.security.ConversationState;
 
 /**
@@ -49,6 +50,10 @@ public class ModifyNodeAction implements Action {
                                                     conversationState.getIdentity().getUserId();
     if(node.canAddMixin("exo:modify")) {
       node.addMixin("exo:modify");
+    }
+    String propertyName =((PropertyImpl) item).getInternalName().getName();
+    if (propertyName.equals("documentViews") || propertyName.equals("documentViewers")) {
+      return false;
     }
     node.setProperty("exo:lastModifiedDate", new GregorianCalendar());
     node.setProperty("exo:lastModifier",userName);


### PR DESCRIPTION
Prior to this change, when a user opens a file, the view properties are set, the ModifyNodeAction event listener is executed and the "exo:lastModifiedDate" and "exo:lastModifier" properties are updated, resulting in an incorrect modifier avatar when opening a file to display it without modifying it. After this modification, when a view property is updated, "exo:lastModifiedDate" and "exo:lastModifier" do not change.