### PR TITLE
fix: Log errors related to Documents - EXO-70478

### DIFF
--- a/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/action/ModifyNodeAction.java
+++ b/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/action/ModifyNodeAction.java
@@ -51,9 +51,11 @@ public class ModifyNodeAction implements Action {
     if(node.canAddMixin("exo:modify")) {
       node.addMixin("exo:modify");
     }
-    String propertyName =((PropertyImpl) item).getInternalName().getName();
-    if (propertyName.equals("documentViews") || propertyName.equals("documentViewers")) {
-      return false;
+    if (item instanceof Property) {
+      String propertyName = ((PropertyImpl) item).getInternalName().getName();
+      if (propertyName.equals("documentViews") || propertyName.equals("documentViewers")) {
+        return false;
+      }
     }
     node.setProperty("exo:lastModifiedDate", new GregorianCalendar());
     node.setProperty("exo:lastModifier",userName);


### PR DESCRIPTION
The [fix](https://github.com/exoplatform/jcr/commit/5e5a8aa4995d5f98eb6f06a8120fb79a4074cd0f#diff-cc7c2bb84e5dd34a7d4aefdcad160bb5c5e2b9d08337bed35a729f9bb9043f6dR55) to avoid setting lastModifiedDate and lastModifier when upadating documents views properties causes ClassCastException when the updated item is not a property.
This fix avoid that by checking if the item is a propety before getting its name.