### PR TITLE
fix: Fix reading File Binary Meta Data - exoplatform/exip#21

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/document/impl/OpenOfficeDocumentReader.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/document/impl/OpenOfficeDocumentReader.java
@@ -164,9 +164,11 @@ public class OpenOfficeDocumentReader extends BaseDocumentReader
          try
          {
             ZipEntry ze = zis.getNextEntry();
-            while (!ze.getName().equals("meta.xml"))
-            {
-               ze = zis.getNextEntry();
+            while (ze != null && !ze.getName().equals("meta.xml")) {
+              ze = zis.getNextEntry();
+            }
+            if (ze == null) {
+              throw new DocumentReadException("Can't find file 'meta.xml'");
             }
 
             OpenOfficeMetaHandler metaHandler = new OpenOfficeMetaHandler();


### PR DESCRIPTION
Sometimes an NPE is thrown when the Metadata can't be read from uploaded Image Binary. This change will fix this NPE.

Resolves exoplatform/exip#21