### PR TITLE
fix: Update commons-fileupload2-jakarta:2.0.0-M1 to commons-fileupload2-jakarta-servlet6:2.0.0-M4 - MEED-9913 - Meeds-io/meeds#3809

### DIFF
--- a/exo.jcr.framework.command/src/main/java/org/exoplatform/frameworks/jcr/command/web/fckeditor/UploadFileCommand.java
+++ b/exo.jcr.framework.command/src/main/java/org/exoplatform/frameworks/jcr/command/web/fckeditor/UploadFileCommand.java
@@ -31,7 +31,7 @@ import org.apache.commons.chain.Command;
 import org.apache.commons.chain.Context;
 import org.apache.commons.fileupload2.core.DiskFileItem;
 import org.apache.commons.fileupload2.core.FileItem;
-import org.apache.commons.fileupload2.jakarta.JakartaServletDiskFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletDiskFileUpload;
 
 import org.exoplatform.frameworks.jcr.command.JCRCommandHelper;
 import org.exoplatform.frameworks.jcr.command.web.GenericWebAppContext;


### PR DESCRIPTION
Update this dependency to fix CVE-2025-48976

Resolves Meeds-io/meeds#3809