### PR TITLE
fix: Error Parsing XLS doesn't update File Metadata - EXO-87632

### DIFF
--- a/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/metadata/AddMetadataAction.java
+++ b/exo.jcr.component.ext/src/main/java/org/exoplatform/services/jcr/ext/metadata/AddMetadataAction.java
@@ -83,16 +83,7 @@ public class AddMetadataAction implements Action
             setJCRProperties(parent, props);
          }
       }
-      catch (HandlerNotFoundException e)
-      {
-         LOG.debug("Binary value reader error, content by path " + property.getPath() + ", property id "
-            + property.getData().getIdentifier() + " : " + e.getMessage());
-      }
-      catch (IOException e)
-      {
-         printWarning(property, e);
-      }
-      catch (DocumentReadException e)
+      catch (Exception e)
       {
          printWarning(property, e);
       }
@@ -134,20 +125,24 @@ public class AddMetadataAction implements Action
     * Print warning message on the console
     * 
     * @param property property that has not been read
-    * @param exception the reason for which wasn't read property
+    * @param e the reason for which wasn't read property
     * @throws RepositoryException
     */
-   private void printWarning(PropertyImpl property, Exception exception) throws RepositoryException
+   private void printWarning(PropertyImpl property, Exception e) throws RepositoryException
    {
-      if (PropertyManager.isDevelopping())
+      if (PropertyManager.isDevelopping() || LOG.isDebugEnabled())
       {
-         LOG.warn("Binary value reader error, content by path " + property.getPath() + ", property id "
-            + property.getData().getIdentifier() + " : " + exception.getMessage(), exception);
+        LOG.warn("Binary value reader error, content by path '{}', property id '{}'. Add empty dc:elementSet properties to file",
+                 property.getPath(),
+                 property.getData().getIdentifier(),
+                 e);
       }
       else
       {
-         LOG.warn("Binary value reader error, content by path " + property.getPath() + ", property id "
-            + property.getData().getIdentifier() + " : " + exception.getMessage());
+        LOG.warn("Binary value reader error, content by path '{}', property id '{}'. Add empty dc:elementSet properties to file. Error (Enable Debug for full stack trace): {}",
+                 property.getPath(),
+                 property.getData().getIdentifier(),
+                 e.getMessage());
       }
    }
 


### PR DESCRIPTION
Prior to this change a full stack trace is logged when a non-blocker operation is made on a file to extract the File Metadata and its related dc:elementSet properties. This change ensures to have the adequate log message without a full stack trace only in Debug Level.